### PR TITLE
updated reference from lit pod to solid-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1405,6 +1405,20 @@
       "integrity": "sha512-hC5cFNOfRiUfyzosJ3tmod6M8xBGH2obM49BEiwvEOcr9lxU8TAOeM6bgT7z+uGMaJ25GqGfIk30poa0ijMn+w==",
       "dev": true
     },
+    "@inrupt/solid-client": {
+      "version": "0.0.2-master-185438310-580.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-0.0.2-master-185438310-580.0.tgz",
+      "integrity": "sha512-2Uuo0k0N5YCM/S2zft1zc3+ztFvuExOVAifYZCxGTi43ssALfIpxXmsrCpULNnzuWhPCaw4TVhI+WRiA19DT6w==",
+      "requires": {
+        "@rdfjs/dataset": "^1.0.1",
+        "@types/n3": "^1.1.6",
+        "@types/rdf-js": "^3.0.1",
+        "@types/rdfjs__dataset": "^1.0.2",
+        "cross-fetch": "^3.0.4",
+        "http-link-header": "^1.0.2",
+        "n3": "^1.4.0"
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
+    "@inrupt/solid-client": "0.0.2-master-185438310-580.0",
     "@material-ui/core": "^4.11.0",
-    "@solid/lit-pod": "0.0.2-chorerename-137272289-92.0",
     "@types/solid-auth-client": "^2.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updating to the renamed `@inrupt/solid-client` from the old `@solid/lit-pod`