### PR TITLE
Feature/link rel noopener

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-ui-react",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-ui-react",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "description": "Set of UI libraries using @solid/core",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/link/index.test.tsx
+++ b/src/components/link/index.test.tsx
@@ -75,12 +75,37 @@ describe("Link component", () => {
         thing={mockThing}
         property={mockPredicate}
         className="test-class"
-        target="_blank"
-        rel="noreferrer"
+        target="_self"
+        rel="abcd"
       />
     );
-    expect(getByText(mockUrl).getAttribute("target")).toBe("_blank");
+    expect(getByText(mockUrl).getAttribute("target")).toBe("_self");
     expect(getByText(mockUrl).getAttribute("class")).toBe("test-class");
-    expect(getByText(mockUrl).getAttribute("rel")).toBe("noreferrer");
+    expect(getByText(mockUrl).getAttribute("rel")).toBe("abcd");
+  });
+
+  it("Defaults rel to 'noopener noreferrer' if target=_blank", () => {
+    const { getByText } = render(
+      <Link
+        thing={mockThing}
+        property={mockPredicate}
+        className="test-class"
+        target="_blank"
+      />
+    );
+    expect(getByText(mockUrl).getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("Overrides rel if passed in", () => {
+    const { getByText } = render(
+      <Link
+        thing={mockThing}
+        property={mockPredicate}
+        className="test-class"
+        target="_blank"
+        rel="test"
+      />
+    );
+    expect(getByText(mockUrl).getAttribute("rel")).toBe("test");
   });
 });

--- a/src/components/link/index.tsx
+++ b/src/components/link/index.tsx
@@ -31,10 +31,14 @@ export default function Link({
   children,
   property,
   thing,
-  rel = "nofollow",
+  rel,
+  target,
   ...linkOptions
 }: Props): ReactElement {
   const href = getUrlOne(thing, property);
+
+  const adjustedRel =
+    rel || (target === "_blank" ? "noopener noreferrer" : "nofollow");
 
   if (!href) {
     throw new Error("URL not found for given property");
@@ -42,7 +46,7 @@ export default function Link({
 
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading
-    <a href={href} rel={rel} {...linkOptions}>
+    <a href={href} rel={adjustedRel} target={target} {...linkOptions}>
       {children ?? href}
     </a>
   );


### PR DESCRIPTION
# Added functionality that changes the rel attribute based on the target

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).