### PR TITLE
fix/update ThingProvider stateThing in response to change in thing prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.1 ( September 24, 2020 )
+
+### Changed
+
+- ThingProvider correctly updates its stored Thing in state in response to changes in `thing` prop
+
 ## 1.2.0 ( September 23, 2020 )
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-ui-react",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-ui-react",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Set of UI libraries using @solid/core",
   "main": "dist/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/context/thingContext/index.tsx
+++ b/src/context/thingContext/index.tsx
@@ -74,8 +74,10 @@ export const ThingProvider = ({
   useEffect(() => {
     if (dataset && thingUrl) {
       setThing(getThing(dataset, thingUrl));
+    } else {
+      setThing(propThing);
     }
-  }, [dataset, thingUrl]);
+  }, [dataset, thingUrl, propThing]);
 
   return (
     <ThingContext.Provider value={{ thing: stateThing, setThing }}>


### PR DESCRIPTION
- Fix for ThingProvider holding on to local Thing even when value of prop 'thing' changes