### PR TITLE
Allow setting table row props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.3.0 ( September 30, 2020 )
+
+### Added
+
+- Added `getRowProps` to `<Table>`, allowing a function to be provided to generate attributes for
+  each `<tr>`, based on row data.
+
 ## 1.2.1 ( September 24, 2020 )
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-ui-react",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-ui-react",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Set of UI libraries using @solid/core",
   "main": "dist/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -26,6 +26,7 @@ import { SolidDataset, Thing, Url, UrlString } from "@inrupt/solid-client";
 import {
   useTable,
   Column,
+  Row,
   useSortBy,
   useGlobalFilter,
   Renderer,
@@ -60,6 +61,11 @@ export interface TableProps
   filter?: string;
   ascIndicator?: ReactNode;
   descIndicator?: ReactNode;
+  getRowProps: (
+    row: Row,
+    rowThing: Thing,
+    rowDataset: SolidDataset
+  ) => React.HTMLAttributes<HTMLTableRowElement>;
 }
 
 export function Table({
@@ -68,6 +74,7 @@ export function Table({
   filter,
   ascIndicator,
   descIndicator,
+  getRowProps,
   ...tableProps
 }: TableProps): ReactElement {
   const { columns, data } = useMemo(() => {
@@ -139,7 +146,7 @@ export function Table({
           const rowDataset = things[row.index].dataset;
           const rowThing = things[row.index].thing;
           return (
-            <tr {...row.getRowProps()}>
+            <tr {...row.getRowProps(getRowProps(row, rowThing, rowDataset))}>
               <CombinedDataProvider dataset={rowDataset} thing={rowThing}>
                 {row.cells.map((cell) => {
                   return (
@@ -169,4 +176,5 @@ Table.defaultProps = {
       🔽
     </span>
   ),
+  getRowProps: () => ({}),
 };


### PR DESCRIPTION
- Add `getRowProps` prop to `Table` — allows using row data (react-table row object, row thing, and row dataset) to generate attributes for `<tr>`