### PR TITLE
Remove logout workaround

### DIFF
--- a/src/context/sessionContext/index.tsx
+++ b/src/context/sessionContext/index.tsx
@@ -111,9 +111,6 @@ export const SessionProvider = ({
       });
 
     session.on("logout", () => {
-      // Workaround for a solid-client-authn bug.
-      // It leaves dirty data in localstorage, and doesn't set isLoggedIn to false after logging out.
-      window.localStorage.clear();
       setSession(buildSession(sessionId));
     });
   }, [session, sessionId]);


### PR DESCRIPTION
The local storage is now properly cleared by solid-client-authn, so this workaround is no longer necessary, and actually introduces a bug because it creates a race condition between solid-client-authn and the component. Should only be merged after https://github.com/inrupt/solid-client-authn-js/tree/1.x is merged into master and released.

- [ ] I've added a unit test to test for potential regressions of this bug. -> N/A, the bug is fixed and tested for in solid-client-authn 
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).