### PR TITLE
Make sessionId optional for SessionProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.6.1 ( November 3, 2020 )
+
+### Changed
+
+- `sessionId` is now optional for `SessionProvider`
+
 ## 1.6.0 ( October 27, 2020 )
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-ui-react",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Set of UI libraries using @solid/core",
   "main": "dist/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/context/sessionContext/__snapshots__/index.test.tsx.snap
+++ b/src/context/sessionContext/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Testing SessionContext matches snapshot matches snapshot 1`] = `
+exports[`Testing SessionContext matches snapshot 1`] = `
+<body>
+  <div>
+    <div>
+      <div
+        data-testid="session"
+      >
+        {"info":{"isLoggedIn":true,"webId":"https://fakeurl.com/me"}}
+      </div>
+      <button
+        type="button"
+      >
+        Login
+      </button>
+      <button
+        type="button"
+      >
+        Logout
+      </button>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Testing SessionContext matches snapshot without optional sessionId 1`] = `
 <body>
   <div>
     <div>

--- a/src/context/sessionContext/index.test.tsx
+++ b/src/context/sessionContext/index.test.tsx
@@ -46,7 +46,7 @@ function ChildComponent(): React.ReactElement {
   );
 }
 
-describe("Testing SessionContext matches snapshot", () => {
+describe("Testing SessionContext", () => {
   it("matches snapshot", async () => {
     const session = {
       info: {
@@ -62,6 +62,33 @@ describe("Testing SessionContext matches snapshot", () => {
 
     const documentBody = render(
       <SessionProvider session={session} sessionId="key">
+        <ChildComponent />
+      </SessionProvider>
+    );
+
+    await waitFor(() => {
+      expect(session.handleIncomingRedirect).toHaveBeenCalled();
+    });
+
+    const { baseElement } = documentBody;
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it("matches snapshot without optional sessionId", async () => {
+    const session = {
+      info: {
+        isLoggedIn: true,
+        webId: "https://fakeurl.com/me",
+      },
+      handleIncomingRedirect: jest.fn().mockResolvedValue(null),
+      on: jest.fn(),
+      fetch: jest.fn(),
+      login: jest.fn(),
+      logout: jest.fn(),
+    } as any;
+
+    const documentBody = render(
+      <SessionProvider session={session}>
         <ChildComponent />
       </SessionProvider>
     );

--- a/src/context/sessionContext/index.tsx
+++ b/src/context/sessionContext/index.tsx
@@ -52,7 +52,7 @@ export const unauthenticatedFetch = (url: any, options: any): any => {
   return window.fetch.call(window, url, options);
 };
 
-export const buildSession = (sessionId: string): Session =>
+export const buildSession = (sessionId?: string): Session =>
   new Session(
     {
       clientAuthentication: getClientAuthenticationWithDependencies({}),
@@ -75,7 +75,7 @@ export const SessionContext = createContext<ISessionContext>({
 /* eslint react/require-default-props: 0 */
 export interface ISessionProvider {
   children: ReactNode;
-  sessionId: string;
+  sessionId?: string;
   session?: Session;
   sessionRequestInProgress?: boolean;
   onError?: (error: Error) => void;


### PR DESCRIPTION
This PR fixes #4 by making SessionProvider's `sessionId` property optional.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).