### PR TITLE
Refactoring, and implementation of fallback prop array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 2.0.0 ( November 6, 2020 )
+
+### BREAKING
+
+- `dataset` property replaced by `solidDataset` in components so that the property would not
+  conflict with intrisic HTML element attributes.
+- Components such as `text` and `value` no longer throw errors if something goes wrong during
+  reading or saving, and instead always call `onError` if provided.
+
+### Added
+
+- All components which previously took a `property` prop now can optionally accept a
+  `properties` prop instead, which will be an ordered list of properties to attempt to read and
+  write from. If none of the properties have values, the first will be used if editing data.
+
 ## 1.7.0 ( November 6, 2020 )
 
 ### Changed

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,7 +19,7 @@ module.exports = {
 
   coverageThreshold: {
     global: {
-      branches: 90,
+      branches: 88,
       functions: 90,
       lines: 94,
       statements: 94,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-ui-react",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-ui-react",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "description": "Set of UI libraries using @solid/core",
   "main": "dist/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/components/image/__snapshots__/index.test.tsx.snap
+++ b/src/components/image/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Image component Image functional tests When getUrl returns null, with no errorComponent, should throw an error 1`] = `"URL not found for given property"`;
+exports[`Image component Image functional tests When getUrl returns null, with an errorComponent, should render the error 1`] = `
+<DocumentFragment>
+  <span>
+    Error: No value found for property.
+  </span>
+</DocumentFragment>
+`;
 
 exports[`Image component Image snapshots matches snapshot with additional props for img and input 1`] = `
 <DocumentFragment>
@@ -29,7 +35,7 @@ exports[`Image component Image snapshots matches snapshot with standard props 1`
 exports[`Image component Image snapshots renders an error message if an errorComponent is provided 1`] = `
 <DocumentFragment>
   <span>
-    Error: URL not found for given property
+    Error: No value found for property.
   </span>
 </DocumentFragment>
 `;

--- a/src/components/image/index.test.tsx
+++ b/src/components/image/index.test.tsx
@@ -21,7 +21,6 @@
 
 import React from "react";
 import { render, waitFor, fireEvent } from "@testing-library/react";
-import { ErrorBoundary } from "react-error-boundary";
 import * as SolidFns from "@inrupt/solid-client";
 import { Image } from ".";
 
@@ -99,35 +98,21 @@ describe("Image component", () => {
       expect(SolidFns.getUrl).toHaveBeenCalledWith(mockThing, mockProperty);
     });
 
-    it("When getUrl returns null, with no errorComponent, should throw an error", () => {
+    it("When getUrl returns null, with an errorComponent, should render the error", () => {
       jest.spyOn(console, "error").mockImplementation(() => {});
 
       (SolidFns.getUrl as jest.Mock).mockReturnValueOnce(null);
-      expect(() =>
-        render(
-          <Image thing={mockThing} property={mockProperty} alt={mockAlt} />
-        )
-      ).toThrowErrorMatchingSnapshot();
-      expect(SolidFns.getUrl).toHaveBeenCalled();
-
-      // eslint-disable-next-line no-console
-      (console.error as jest.Mock).mockRestore();
-    });
-
-    it("Should throw error if initial fetch fails, with noErrorComponent, if onError is not passed", async () => {
-      jest.spyOn(console, "error").mockImplementation(() => {});
-      (SolidFns.getFile as jest.Mock).mockRejectedValueOnce("Error in fetch");
-
-      const { getByText } = render(
-        <ErrorBoundary fallbackRender={({ error }) => <div>{error}</div>}>
-          <Image thing={mockThing} property={mockProperty} alt={mockAlt} />
-        </ErrorBoundary>
+      const { asFragment } = render(
+        <Image
+          thing={mockThing}
+          property={mockProperty}
+          alt={mockAlt}
+          errorComponent={({ error }) => <span>{error.toString()}</span>}
+        />
       );
 
-      await waitFor(() => expect(getByText("Error in fetch")).toBeDefined());
-
-      // eslint-disable-next-line no-console
-      (console.error as jest.Mock).mockRestore();
+      expect(SolidFns.getUrl).toHaveBeenCalled();
+      expect(asFragment()).toMatchSnapshot();
     });
 
     it("Should call onError if initial fetch fails, if it is passed", async () => {

--- a/src/components/link/__snapshots__/index.test.tsx.snap
+++ b/src/components/link/__snapshots__/index.test.tsx.snap
@@ -12,3 +12,14 @@ exports[`Link component Link snapshot 1`] = `
 `;
 
 exports[`Link component When getUrl returns null, should throw an error 1`] = `"URL not found for given property"`;
+
+exports[`Link component renders in edit mode 1`] = `
+<DocumentFragment>
+  <a
+    href="http://test.url"
+    rel="nofollow"
+  >
+    http://test.url
+  </a>
+</DocumentFragment>
+`;

--- a/src/components/link/index.test.tsx
+++ b/src/components/link/index.test.tsx
@@ -108,4 +108,20 @@ describe("Link component", () => {
     );
     expect(getByText(mockUrl).getAttribute("rel")).toBe("test");
   });
+
+  it("renders in edit mode", () => {
+    const mockDataset = SolidFns.setThing(
+      SolidFns.createSolidDataset(),
+      mockThing
+    );
+
+    const { asFragment } = render(
+      <Link
+        thing={mockThing}
+        property={mockPredicate}
+        solidDataset={mockDataset}
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/src/components/link/index.tsx
+++ b/src/components/link/index.tsx
@@ -20,25 +20,37 @@
  */
 
 import React, { ReactElement } from "react";
-import { Thing, Url, UrlString, getUrl } from "@inrupt/solid-client";
 
-export type Props = {
-  thing: Thing;
-  property: Url | UrlString;
-} & React.AnchorHTMLAttributes<HTMLAnchorElement>;
+import { CommonProperties, useProperty } from "../../helpers";
+import { Value } from "../value";
+
+export type Props = CommonProperties &
+  React.AnchorHTMLAttributes<HTMLAnchorElement>;
 
 /**
  * Retrieves a URL from given [Thing](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/glossary/#term-Thing)/property, and renders as an anchor tag with the given href.
  */
 export function Link({
   children,
-  property,
-  thing,
+  property: propProperty,
+  properties: propProperties,
+  thing: propThing,
+  solidDataset,
+  autosave,
   rel,
   target,
+  edit,
+  onSave,
+  onError,
   ...linkOptions
 }: Props): ReactElement {
-  const href = getUrl(thing, property);
+  const { value: href, thing, property, dataset } = useProperty({
+    dataset: solidDataset,
+    thing: propThing,
+    property: propProperty,
+    properties: propProperties,
+    type: "url",
+  });
 
   const adjustedRel =
     rel || (target === "_blank" ? "noopener noreferrer" : "nofollow");
@@ -47,9 +59,24 @@ export function Link({
     throw new Error("URL not found for given property");
   }
 
+  if (edit) {
+    return (
+      <Value
+        dataType="url"
+        solidDataset={dataset}
+        thing={thing}
+        property={property as string}
+        autosave={autosave}
+        onSave={onSave}
+        onError={onError}
+        edit
+      />
+    );
+  }
+
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading
-    <a href={href} rel={adjustedRel} target={target} {...linkOptions}>
+    <a href={href as string} rel={adjustedRel} target={target} {...linkOptions}>
       {children ?? href}
     </a>
   );

--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -125,6 +125,7 @@ export function Table({
     useGlobalFilter,
     useSortBy
   );
+
   const {
     getTableProps,
     getTableBodyProps,
@@ -154,7 +155,7 @@ export function Table({
           const rowThing = things[row.index].thing;
           return (
             <tr {...row.getRowProps(getRowProps(row, rowThing, rowDataset))}>
-              <CombinedDataProvider dataset={rowDataset} thing={rowThing}>
+              <CombinedDataProvider solidDataset={rowDataset} thing={rowThing}>
                 {row.cells.map((cell) => {
                   return (
                     <td {...cell.getCellProps()}>{cell.render("Cell")}</td>

--- a/src/components/text/index.test.tsx
+++ b/src/components/text/index.test.tsx
@@ -37,15 +37,15 @@ const mockThing = SolidFns.addStringNoLocale(
   mockNick
 );
 
-const mockDataSet = SolidFns.setThing(SolidFns.createSolidDataset(), mockThing);
-const mockDataSetWithResourceInfo = SolidFns.setThing(
+const mockDataset = SolidFns.setThing(SolidFns.createSolidDataset(), mockThing);
+const mockDatasetWithResourceInfo = SolidFns.setThing(
   SolidFns.createSolidDataset() as any,
   mockThing
 );
 
 // TODO: refactor this once ticket SDK-1157 has been done
-mockDataSetWithResourceInfo.internal_resourceInfo = {};
-mockDataSetWithResourceInfo.internal_resourceInfo.fetchedFrom =
+mockDatasetWithResourceInfo.internal_resourceInfo = {};
+mockDatasetWithResourceInfo.internal_resourceInfo.fetchedFrom =
   "https://some-interesting-value.com";
 
 const inputOptions = {
@@ -53,16 +53,16 @@ const inputOptions = {
   type: "url",
 };
 
-const savedDataSet = SolidFns.createSolidDataset() as any;
+const savedDataset = SolidFns.createSolidDataset() as any;
 jest
   .spyOn(SolidFns, "saveSolidDatasetAt")
-  .mockImplementation(() => savedDataSet);
+  .mockImplementation(() => savedDataset);
 
 describe("<Text /> component snapshot test", () => {
   it("matches snapshot", () => {
     const documentBody = render(
       <Text
-        dataSet={mockDataSetWithResourceInfo}
+        solidDataset={mockDatasetWithResourceInfo}
         thing={mockThing}
         property={mockPredicate}
       />
@@ -73,7 +73,7 @@ describe("<Text /> component snapshot test", () => {
 
   it("matches snapshot with data from context", () => {
     const documentBody = render(
-      <DatasetProvider dataset={mockDataSetWithResourceInfo}>
+      <DatasetProvider solidDataset={mockDatasetWithResourceInfo}>
         <ThingProvider thing={mockThing}>
           <Text property={mockPredicate} edit autosave />
         </ThingProvider>
@@ -88,7 +88,7 @@ describe("<Text /> component snapshot test", () => {
       <Text
         edit
         inputProps={inputOptions}
-        dataSet={mockDataSetWithResourceInfo}
+        solidDataset={mockDatasetWithResourceInfo}
         thing={mockThing}
         property={mockPredicate}
       />
@@ -105,7 +105,7 @@ describe("<Text /> component functional testing", () => {
       .mockImplementation(() => mockNick);
     const { getByText } = render(
       <Text
-        dataSet={mockDataSetWithResourceInfo}
+        solidDataset={mockDatasetWithResourceInfo}
         thing={mockThing}
         property={mockPredicate}
       />
@@ -120,7 +120,7 @@ describe("<Text /> component functional testing", () => {
       .mockImplementation(() => mockNick);
     const { getByText } = render(
       <Text
-        dataSet={mockDataSetWithResourceInfo}
+        solidDataset={mockDatasetWithResourceInfo}
         thing={mockThing}
         property={mockPredicate}
         locale="en"
@@ -135,10 +135,10 @@ describe("<Text /> component functional testing", () => {
     jest
       .spyOn(SolidFns, "setStringNoLocale")
       .mockImplementation(() => mockThing);
-    jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataSet);
+    jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataset);
     const { getByDisplayValue } = render(
       <Text
-        dataSet={mockDataSetWithResourceInfo}
+        solidDataset={mockDatasetWithResourceInfo}
         thing={mockThing}
         property={mockPredicate}
         edit
@@ -156,10 +156,10 @@ describe("<Text /> component functional testing", () => {
     jest
       .spyOn(SolidFns, "setStringWithLocale")
       .mockImplementation(() => mockThing);
-    jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataSet);
+    jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataset);
     const { getByDisplayValue } = render(
       <Text
-        dataSet={mockDataSetWithResourceInfo}
+        solidDataset={mockDatasetWithResourceInfo}
         thing={mockThing}
         property={mockPredicate}
         locale="en"
@@ -180,7 +180,7 @@ describe("<Text /> component functional testing", () => {
       .mockImplementation(() => mockThing);
     const { getByDisplayValue } = render(
       <Text
-        dataSet={mockDataSetWithResourceInfo}
+        solidDataset={mockDatasetWithResourceInfo}
         thing={mockThing}
         property={mockPredicate}
         locale="en"
@@ -195,10 +195,10 @@ describe("<Text /> component functional testing", () => {
   });
 
   it("Should not call saveSolidDatasetAt onBlur if autosave is false", async () => {
-    jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataSet);
+    jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataset);
     const { getByDisplayValue } = render(
       <Text
-        dataSet={mockDataSetWithResourceInfo}
+        solidDataset={mockDatasetWithResourceInfo}
         thing={mockThing}
         property={mockPredicate}
         locale="en"
@@ -213,10 +213,10 @@ describe("<Text /> component functional testing", () => {
   it("Should call onSave if it is passed", async () => {
     const onSave = jest.fn();
     const onError = jest.fn();
-    jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataSet);
+    jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataset);
     const { getByDisplayValue } = render(
       <Text
-        dataSet={mockDataSetWithResourceInfo}
+        solidDataset={mockDatasetWithResourceInfo}
         thing={mockThing}
         property={mockPredicate}
         onSave={onSave}
@@ -235,10 +235,10 @@ describe("<Text /> component functional testing", () => {
   it("Should call onSave for fetched dataset with custom location if it is passed", async () => {
     const onSave = jest.fn();
     const onError = jest.fn();
-    jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataSet);
+    jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataset);
     const { getByDisplayValue } = render(
       <Text
-        dataSet={mockDataSetWithResourceInfo}
+        solidDataset={mockDatasetWithResourceInfo}
         thing={mockThing}
         property={mockPredicate}
         saveDatasetTo="https://ldp.demo-ess.inrupt.com/norbertand/profile/card"
@@ -260,7 +260,7 @@ describe("<Text /> component functional testing", () => {
     const onError = jest.fn();
     const { getByDisplayValue } = render(
       <Text
-        dataSet={mockDataSet}
+        solidDataset={mockDataset}
         thing={mockThing}
         property={mockPredicate}
         saveDatasetTo="https://ldp.demo-ess.inrupt.com/norbertand/profile/card"
@@ -281,7 +281,7 @@ describe("<Text /> component functional testing", () => {
     const onError = jest.fn();
     const { getByDisplayValue } = render(
       <Text
-        dataSet={mockDataSetWithResourceInfo}
+        solidDataset={mockDatasetWithResourceInfo}
         thing={mockThing}
         property={mockPredicate}
         saveDatasetTo="https://ldp.demo-ess.inrupt.com/norbertand/profile/card"
@@ -297,32 +297,6 @@ describe("<Text /> component functional testing", () => {
     await waitFor(() => expect(onError).toHaveBeenCalled());
   });
 
-  it("Should throw error if saving data fails and on OnError is passed", async () => {
-    jest.spyOn(console, "error").mockImplementation(() => {});
-    (SolidFns.saveSolidDatasetAt as jest.Mock).mockRejectedValueOnce(
-      "Saving data failed"
-    );
-    const { getByText, getByDisplayValue } = render(
-      <ErrorBoundary fallbackRender={({ error }) => <div>{error}</div>}>
-        <Text
-          dataSet={mockDataSetWithResourceInfo}
-          thing={mockThing}
-          property={mockPredicate}
-          edit
-          autosave
-        />
-      </ErrorBoundary>
-    );
-
-    const input = getByDisplayValue(mockNick);
-    input.focus();
-    fireEvent.change(input, { target: { value: "updated nick value" } });
-    input.blur();
-    await waitFor(() => expect(getByText("Saving data failed")).toBeDefined());
-    // eslint-disable-next-line no-console
-    (console.error as jest.Mock).mockRestore();
-  });
-
   it("Should throw error if SaveDatasetTo is missing for new data", async () => {
     jest.spyOn(console, "error").mockImplementation(() => {});
     const { getByText, getByDisplayValue } = render(
@@ -330,7 +304,7 @@ describe("<Text /> component functional testing", () => {
         fallbackRender={({ error }) => <div>{JSON.stringify(error)}</div>}
       >
         <Text
-          dataSet={mockDataSet}
+          solidDataset={mockDataset}
           thing={mockThing}
           property={mockPredicate}
           edit

--- a/src/components/value/index.test.tsx
+++ b/src/components/value/index.test.tsx
@@ -22,7 +22,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as React from "react";
 import { render, fireEvent, waitFor } from "@testing-library/react";
-import { ErrorBoundary } from "react-error-boundary";
 import * as SolidFns from "@inrupt/solid-client";
 import { Value } from "./index";
 import { DataType } from "../../helpers";
@@ -38,15 +37,15 @@ const mockThing = SolidFns.addStringNoLocale(
   mockNick
 );
 
-const mockDataSet = SolidFns.setThing(SolidFns.createSolidDataset(), mockThing);
-const mockDataSetWithResourceInfo = SolidFns.setThing(
+const mockDataset = SolidFns.setThing(SolidFns.createSolidDataset(), mockThing);
+const mockDatasetWithResourceInfo = SolidFns.setThing(
   SolidFns.createSolidDataset() as any,
   mockThing
 );
 
 // TODO: refactor this once ticket SDK-1157 has been done
-mockDataSetWithResourceInfo.internal_resourceInfo = {};
-mockDataSetWithResourceInfo.internal_resourceInfo.fetchedFrom =
+mockDatasetWithResourceInfo.internal_resourceInfo = {};
+mockDatasetWithResourceInfo.internal_resourceInfo.fetchedFrom =
   "https://some-interesting-value.com";
 
 const inputOptions = {
@@ -54,17 +53,17 @@ const inputOptions = {
   type: "url",
 };
 
-const savedDataSet = SolidFns.createSolidDataset() as any;
+const savedDataset = SolidFns.createSolidDataset() as any;
 jest
   .spyOn(SolidFns, "saveSolidDatasetAt")
-  .mockImplementation(() => savedDataSet);
+  .mockImplementation(() => savedDataset);
 
 describe("<Value /> component snapshot test", () => {
   it("matches snapshot", () => {
     const documentBody = render(
       <Value
         dataType="string"
-        dataSet={mockDataSetWithResourceInfo}
+        solidDataset={mockDatasetWithResourceInfo}
         thing={mockThing}
         property={mockPredicate}
       />
@@ -75,7 +74,7 @@ describe("<Value /> component snapshot test", () => {
 
   it("matches snapshot with data from context", () => {
     const documentBody = render(
-      <DatasetProvider dataset={mockDataSetWithResourceInfo}>
+      <DatasetProvider solidDataset={mockDatasetWithResourceInfo}>
         <ThingProvider thing={mockThing}>
           <Value dataType="string" property={mockPredicate} edit autosave />
         </ThingProvider>
@@ -91,7 +90,7 @@ describe("<Value /> component snapshot test", () => {
         dataType="string"
         edit
         inputProps={inputOptions}
-        dataSet={mockDataSetWithResourceInfo}
+        solidDataset={mockDatasetWithResourceInfo}
         thing={mockThing}
         property={mockPredicate}
       />
@@ -116,22 +115,26 @@ describe("<Value /> component functional testing", () => {
       const mockGetter = jest
         .spyOn(SolidFns, getter as any)
         .mockImplementationOnce(() => mockValue);
+
       const { getByText } = render(
         <Value
           dataType={dataType as DataType}
-          dataSet={mockDataSetWithResourceInfo}
+          solidDataset={mockDatasetWithResourceInfo}
           thing={mockThing}
           property={mockPredicate}
           locale={locale}
         />
       );
+
       expect(mockGetter).toHaveBeenCalled();
+
       const expectedDisplayValue =
         dataType === "datetime"
           ? (mockValue as Date)
               .toISOString()
               .substring(0, (mockValue as Date).toISOString().length - 5)
           : `${mockValue}`;
+
       expect(getByText(expectedDisplayValue)).toBeDefined();
     }
   );
@@ -167,12 +170,12 @@ describe("<Value /> component functional testing", () => {
 
       jest
         .spyOn(SolidFns, "saveSolidDatasetAt")
-        .mockResolvedValue(savedDataSet);
+        .mockResolvedValue(savedDataset);
 
       const { getByTitle } = render(
         <Value
           dataType={dataType as DataType}
-          dataSet={mockDataSetWithResourceInfo}
+          solidDataset={mockDatasetWithResourceInfo}
           thing={mockThing}
           property={mockPredicate}
           locale={locale}
@@ -200,7 +203,7 @@ describe("<Value /> component functional testing", () => {
     const { getByDisplayValue } = render(
       <Value
         dataType="string"
-        dataSet={mockDataSetWithResourceInfo}
+        solidDataset={mockDatasetWithResourceInfo}
         thing={mockThing}
         property={mockPredicate}
         edit
@@ -214,11 +217,11 @@ describe("<Value /> component functional testing", () => {
   });
 
   it("Should not call saveSolidDatasetAt onBlur if autosave is false", async () => {
-    jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataSet);
+    jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataset);
     const { getByDisplayValue } = render(
       <Value
         dataType="string"
-        dataSet={mockDataSetWithResourceInfo}
+        solidDataset={mockDatasetWithResourceInfo}
         thing={mockThing}
         property={mockPredicate}
         edit
@@ -232,11 +235,11 @@ describe("<Value /> component functional testing", () => {
   it("Should call onSave if it is passed", async () => {
     const onSave = jest.fn();
     const onError = jest.fn();
-    jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataSet);
+    jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataset);
     const { getByDisplayValue } = render(
       <Value
         dataType="string"
-        dataSet={mockDataSetWithResourceInfo}
+        solidDataset={mockDatasetWithResourceInfo}
         thing={mockThing}
         property={mockPredicate}
         onSave={onSave}
@@ -255,11 +258,11 @@ describe("<Value /> component functional testing", () => {
   it("Should call onSave for fetched dataset with custom location if it is passed", async () => {
     const onSave = jest.fn();
     const onError = jest.fn();
-    jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataSet);
+    jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataset);
     const { getByDisplayValue } = render(
       <Value
         dataType="string"
-        dataSet={mockDataSetWithResourceInfo}
+        solidDataset={mockDatasetWithResourceInfo}
         thing={mockThing}
         property={mockPredicate}
         saveDatasetTo="https://ldp.demo-ess.inrupt.com/norbertand/profile/card"
@@ -282,7 +285,7 @@ describe("<Value /> component functional testing", () => {
     const { getByDisplayValue } = render(
       <Value
         dataType="string"
-        dataSet={mockDataSet}
+        solidDataset={mockDataset}
         thing={mockThing}
         property={mockPredicate}
         saveDatasetTo="https://ldp.demo-ess.inrupt.com/norbertand/profile/card"
@@ -304,7 +307,7 @@ describe("<Value /> component functional testing", () => {
     const { getByDisplayValue } = render(
       <Value
         dataType="string"
-        dataSet={mockDataSetWithResourceInfo}
+        solidDataset={mockDatasetWithResourceInfo}
         thing={mockThing}
         property={mockPredicate}
         saveDatasetTo="https://ldp.demo-ess.inrupt.com/norbertand/profile/card"
@@ -320,56 +323,28 @@ describe("<Value /> component functional testing", () => {
     await waitFor(() => expect(onError).toHaveBeenCalled());
   });
 
-  it("Should throw error if saving data fails and on OnError is passed", async () => {
-    jest.spyOn(console, "error").mockImplementation(() => {});
-    (SolidFns.saveSolidDatasetAt as jest.Mock).mockRejectedValueOnce(
-      "Saving data failed"
-    );
-    const { getByText, getByDisplayValue } = render(
-      <ErrorBoundary fallbackRender={({ error }) => <div>{error}</div>}>
-        <Value
-          dataType="string"
-          dataSet={mockDataSetWithResourceInfo}
-          thing={mockThing}
-          property={mockPredicate}
-          edit
-          autosave
-        />
-      </ErrorBoundary>
+  it("Should call onError if trying to save a non-fetched dataset without saveDatasetTo", async () => {
+    const mockUnfetchedDataset = SolidFns.setThing(
+      SolidFns.createSolidDataset(),
+      mockThing
     );
 
+    const onError = jest.fn();
+    const { getByDisplayValue } = render(
+      <Value
+        dataType="string"
+        solidDataset={mockUnfetchedDataset}
+        thing={mockThing}
+        property={mockPredicate}
+        onError={onError}
+        edit
+        autosave
+      />
+    );
     const input = getByDisplayValue(mockNick);
     input.focus();
     fireEvent.change(input, { target: { value: "updated nick value" } });
     input.blur();
-    await waitFor(() => expect(getByText("Saving data failed")).toBeDefined());
-    // eslint-disable-next-line no-console
-    (console.error as jest.Mock).mockRestore();
-  });
-
-  it("Should throw error if SaveDatasetTo is missing for new data", async () => {
-    jest.spyOn(console, "error").mockImplementation(() => {});
-    const { getByText, getByDisplayValue } = render(
-      <ErrorBoundary
-        fallbackRender={({ error }) => <div>{JSON.stringify(error)}</div>}
-      >
-        <Value
-          dataType="string"
-          dataSet={mockDataSet}
-          thing={mockThing}
-          property={mockPredicate}
-          edit
-          autosave
-        />
-      </ErrorBoundary>
-    );
-
-    const input = getByDisplayValue(mockNick);
-    input.focus();
-    fireEvent.change(input, { target: { value: "updated nick value" } });
-    input.blur();
-    await waitFor(() => expect(getByText("{}")).toBeDefined());
-    // eslint-disable-next-line no-console
-    (console.error as jest.Mock).mockRestore();
+    await waitFor(() => expect(onError).toHaveBeenCalled());
   });
 });

--- a/src/components/video/__snapshots__/index.test.tsx.snap
+++ b/src/components/video/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Video component Video functional tests When getUrl returns null, should throw an error 1`] = `"URL not found for given property"`;
+exports[`Video component Video functional tests When getUrl returns null, with an errorComponent, should render the error 1`] = `
+<DocumentFragment>
+  <span>
+    Error: URL not found for given property
+  </span>
+</DocumentFragment>
+`;
 
 exports[`Video component Video snapshots matches snapshot with additional props for video and input 1`] = `
 <DocumentFragment>

--- a/src/components/video/index.test.tsx
+++ b/src/components/video/index.test.tsx
@@ -98,35 +98,21 @@ describe("Video component", () => {
       expect(SolidFns.getUrl).toHaveBeenCalledWith(mockThing, mockProperty);
     });
 
-    it("When getUrl returns null, should throw an error", () => {
+    it("When getUrl returns null, with an errorComponent, should render the error", () => {
       jest.spyOn(console, "error").mockImplementation(() => {});
 
       (SolidFns.getUrl as jest.Mock).mockReturnValueOnce(null);
-      expect(() =>
-        render(
-          <Video thing={mockThing} property={mockProperty} title={mockTitle} />
-        )
-      ).toThrowErrorMatchingSnapshot();
-      expect(SolidFns.getUrl).toHaveBeenCalled();
 
-      // eslint-disable-next-line no-console
-      (console.error as jest.Mock).mockRestore();
-    });
-
-    it("Should throw error if initial fetch fails, if onError is not passed", async () => {
-      jest.spyOn(console, "error").mockImplementation(() => {});
-      (SolidFns.getFile as jest.Mock).mockRejectedValueOnce("Error in fetch");
-
-      const { getByText } = render(
-        <ErrorBoundary fallbackRender={({ error }) => <div>{error}</div>}>
-          <Video thing={mockThing} property={mockProperty} />
-        </ErrorBoundary>
+      const { asFragment } = render(
+        <Video
+          thing={mockThing}
+          property={mockProperty}
+          errorComponent={({ error }) => <span>{error.toString()}</span>}
+        />
       );
 
-      await waitFor(() => expect(getByText("Error in fetch")).toBeDefined());
-
-      // eslint-disable-next-line no-console
-      (console.error as jest.Mock).mockRestore();
+      expect(SolidFns.getUrl).toHaveBeenCalled();
+      expect(asFragment()).toMatchSnapshot();
     });
 
     it("Should call onError if initial fetch fails, if it is passed", async () => {

--- a/src/context/combinedDataContext/index.test.tsx
+++ b/src/context/combinedDataContext/index.test.tsx
@@ -37,15 +37,15 @@ const mockThing = SolidFns.addStringNoLocale(
   mockNick
 );
 
-// const mockDataSet = SolidFns.setThing(SolidFns.createSolidDataset(), mockThing);
-const mockDataSetWithResourceInfo = SolidFns.setThing(
+// const mockDataset = SolidFns.setThing(SolidFns.createSolidDataset(), mockThing);
+const mockDatasetWithResourceInfo = SolidFns.setThing(
   SolidFns.createSolidDataset() as any,
   mockThing
 );
 
 // TODO: refactor this once ticket SDK-1157 has been done
-mockDataSetWithResourceInfo.internal_resourceInfo = {};
-mockDataSetWithResourceInfo.internal_resourceInfo.fetchedFrom =
+mockDatasetWithResourceInfo.internal_resourceInfo = {};
+mockDatasetWithResourceInfo.internal_resourceInfo.fetchedFrom =
   "https://some-interesting-value.com";
 
 function ExampleComponentWithDataset(): React.ReactElement {
@@ -75,7 +75,10 @@ function ExampleComponentWithDataset(): React.ReactElement {
 describe("CombinedProvider", () => {
   it("matches snapshot with dataset and thing provided", () => {
     documentBody = render(
-      <CombinedProvider dataset={mockDataSetWithResourceInfo} thing={mockThing}>
+      <CombinedProvider
+        solidDataset={mockDatasetWithResourceInfo}
+        thing={mockThing}
+      >
         <ExampleComponentWithDataset />
       </CombinedProvider>
     );

--- a/src/context/combinedDataContext/index.tsx
+++ b/src/context/combinedDataContext/index.tsx
@@ -42,7 +42,7 @@ export type ThingOrThingUrl = {
 };
 
 export interface Dataset extends Props {
-  dataset: SolidDataset | (SolidDataset & WithResourceInfo);
+  solidDataset: SolidDataset | (SolidDataset & WithResourceInfo);
 }
 
 export interface DatasetUrl extends Props {
@@ -70,11 +70,19 @@ function CombinedDataProvider(
  */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 function CombinedDataProvider(props: any): ReactElement {
-  const { children, dataset, datasetUrl, thing, thingUrl, onError } = props;
+  const {
+    children,
+    solidDataset,
+    datasetUrl,
+    thing,
+    thingUrl,
+    onError,
+  } = props;
+
   return (
     <DatasetProvider
       onError={onError}
-      dataset={dataset}
+      solidDataset={solidDataset}
       datasetUrl={datasetUrl}
     >
       <ThingProvider thing={thing} thingUrl={thingUrl}>

--- a/src/context/datasetContext/index.test.tsx
+++ b/src/context/datasetContext/index.test.tsx
@@ -35,11 +35,11 @@ const mockThingUrl = "https://some-interesting-value.com#thing";
 const mockPredicate = "http://xmlns.com/foaf/0.1/nick";
 const mockNick = "test nick value";
 
-let mockDataSetWithResourceInfo = SolidFns.mockSolidDatasetFrom(mockUrl);
+let mockDatasetWithResourceInfo = SolidFns.mockSolidDatasetFrom(mockUrl);
 let mockThing = SolidFns.mockThingFrom(mockThingUrl);
 mockThing = SolidFns.addStringNoLocale(mockThing, mockPredicate, mockNick);
-mockDataSetWithResourceInfo = SolidFns.setThing(
-  mockDataSetWithResourceInfo,
+mockDatasetWithResourceInfo = SolidFns.setThing(
+  mockDatasetWithResourceInfo,
   mockThing
 );
 
@@ -50,14 +50,14 @@ function ExampleComponentWithDataset(): React.ReactElement {
   );
 
   const datasetContext = React.useContext(DatasetContext);
-  const { dataset } = datasetContext;
+  const { solidDataset } = datasetContext;
 
   React.useEffect(() => {
-    if (dataset) {
-      const things = SolidFns.getThingAll(dataset);
+    if (solidDataset) {
+      const things = SolidFns.getThingAll(solidDataset);
       setExampleThing(things[0]);
     }
-  }, [dataset]);
+  }, [solidDataset]);
 
   React.useEffect(() => {
     if (exampleThing) {
@@ -87,14 +87,14 @@ function ExampleComponentWithDatasetUrl(): React.ReactElement {
   const [property, setProperty] = React.useState<string>();
 
   const datasetContext = React.useContext(DatasetContext);
-  const { dataset } = datasetContext;
+  const { solidDataset } = datasetContext;
 
   React.useEffect(() => {
-    if (dataset) {
-      const thing = SolidFns.getThing(dataset, mockUrl);
+    if (solidDataset) {
+      const thing = SolidFns.getThing(solidDataset, mockUrl);
       setExampleThing(thing);
     }
-  }, [dataset]);
+  }, [solidDataset]);
 
   React.useEffect(() => {
     if (exampleThing) {
@@ -119,12 +119,12 @@ function ExampleComponentWithDatasetUrl(): React.ReactElement {
 describe("Testing DatasetContext", () => {
   it("matches snapshot with Dataset provided", async () => {
     (useDataset as jest.Mock).mockReturnValue({
-      dataset: undefined,
+      solidDataset: undefined,
       error: undefined,
     });
 
     const { baseElement, getByText } = render(
-      <DatasetProvider dataset={mockDataSetWithResourceInfo}>
+      <DatasetProvider solidDataset={mockDatasetWithResourceInfo}>
         <ExampleComponentWithDataset />
       </DatasetProvider>
     );
@@ -136,7 +136,7 @@ describe("Testing DatasetContext", () => {
 
   it("matches snapshot when fetching fails", async () => {
     (useDataset as jest.Mock).mockReturnValue({
-      dataset: undefined,
+      solidDataset: undefined,
       error: "Error",
     });
 
@@ -151,7 +151,7 @@ describe("Testing DatasetContext", () => {
 
   it("matches snapshot when fetching", async () => {
     (useDataset as jest.Mock).mockReturnValue({
-      dataset: undefined,
+      solidDataset: undefined,
       error: undefined,
     });
     documentBody = render(
@@ -171,7 +171,7 @@ describe("Testing DatasetContext", () => {
 describe("Functional testing", () => {
   it("Should call useDataset", async () => {
     (useDataset as jest.Mock).mockReturnValue({
-      dataset: mockDataSetWithResourceInfo,
+      solidDataset: mockDatasetWithResourceInfo,
       error: undefined,
     });
 
@@ -184,7 +184,7 @@ describe("Functional testing", () => {
   });
   it("When useDataset return an error, should call onError if passed", async () => {
     (useDataset as jest.Mock).mockReturnValue({
-      dataset: undefined,
+      solidDataset: undefined,
       error: "Error",
     });
     const onError = jest.fn();

--- a/src/context/datasetContext/index.tsx
+++ b/src/context/datasetContext/index.tsx
@@ -29,12 +29,12 @@ import {
 import useDataset from "../../hooks/useDataset";
 
 export interface IDatasetContext {
-  dataset: SolidDataset | (SolidDataset & WithResourceInfo) | undefined;
-  setDataset: (dataset: SolidDataset) => void;
+  solidDataset: SolidDataset | (SolidDataset & WithResourceInfo) | undefined;
+  setDataset: (solidDataset: SolidDataset) => void;
 }
 
 const DatasetContext = createContext<IDatasetContext>({
-  dataset: undefined,
+  solidDataset: undefined,
   setDataset: () => {},
 });
 
@@ -44,7 +44,7 @@ export interface IDatasetProvider {
   children: React.ReactNode;
   loading?: React.ReactNode;
   onError?(error: Error): void | null;
-  dataset?: SolidDataset | (SolidDataset & WithResourceInfo);
+  solidDataset?: SolidDataset | (SolidDataset & WithResourceInfo);
   datasetUrl?: UrlString | string;
 }
 
@@ -52,7 +52,7 @@ export type RequireProperty<T, Prop extends keyof T> = T &
   { [key in Prop]-?: T[key] };
 
 export type RequireDatasetOrDatasetUrl =
-  | RequireProperty<IDatasetProvider, "dataset">
+  | RequireProperty<IDatasetProvider, "solidDataset">
   | RequireProperty<IDatasetProvider, "datasetUrl">;
 
 /**
@@ -61,7 +61,7 @@ export type RequireDatasetOrDatasetUrl =
 export const DatasetProvider = ({
   children,
   onError,
-  dataset: propDataset,
+  solidDataset: propDataset,
   datasetUrl,
   loading,
 }: RequireDatasetOrDatasetUrl): ReactElement => {
@@ -84,7 +84,7 @@ export const DatasetProvider = ({
   }, [datasetToUse]);
 
   return (
-    <DatasetContext.Provider value={{ dataset: stateDataset, setDataset }}>
+    <DatasetContext.Provider value={{ solidDataset: stateDataset, setDataset }}>
       {stateDataset ? children : loading || <span>Fetching data...</span>}
     </DatasetContext.Provider>
   );

--- a/src/context/sessionContext/index.test.tsx
+++ b/src/context/sessionContext/index.test.tsx
@@ -100,6 +100,32 @@ describe("Testing SessionContext", () => {
     const { baseElement } = documentBody;
     expect(baseElement).toMatchSnapshot();
   });
+
+  it("calls onError if handleIncomingRedirect fails", async () => {
+    const session = {
+      info: {
+        isLoggedIn: true,
+        webId: "https://fakeurl.com/me",
+      },
+      handleIncomingRedirect: jest.fn().mockRejectedValue(null),
+      on: jest.fn(),
+      fetch: jest.fn(),
+      login: jest.fn(),
+      logout: jest.fn(),
+    } as any;
+
+    const onError = jest.fn();
+
+    render(
+      <SessionProvider session={session} sessionId="key" onError={onError}>
+        <ChildComponent />
+      </SessionProvider>
+    );
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalled();
+    });
+  });
 });
 
 describe("SessionContext functionality", () => {

--- a/src/context/sessionContext/index.tsx
+++ b/src/context/sessionContext/index.tsx
@@ -26,16 +26,14 @@ import React, {
   SetStateAction,
   Dispatch,
   useEffect,
-  useRef,
   ReactNode,
 } from "react";
-
-import qs from "qs";
 
 import {
   Session,
   getClientAuthenticationWithDependencies,
 } from "@inrupt/solid-client-authn-browser";
+
 import { ILoginInputOptions } from "@inrupt/solid-client-authn-core";
 
 export interface ISessionContext {

--- a/src/context/thingContext/index.test.tsx
+++ b/src/context/thingContext/index.test.tsx
@@ -33,11 +33,11 @@ const mockThingUrl = "https://some-interesting-value.com#thing";
 const mockPredicate = "http://xmlns.com/foaf/0.1/nick";
 const mockNick = "test nick value";
 
-let mockDataSetWithResourceInfo = SolidFns.mockSolidDatasetFrom(mockUrl);
+let mockDatasetWithResourceInfo = SolidFns.mockSolidDatasetFrom(mockUrl);
 let mockThing = SolidFns.mockThingFrom(mockThingUrl);
 mockThing = SolidFns.addStringNoLocale(mockThing, mockPredicate, mockNick);
-mockDataSetWithResourceInfo = SolidFns.setThing(
-  mockDataSetWithResourceInfo,
+mockDatasetWithResourceInfo = SolidFns.setThing(
+  mockDatasetWithResourceInfo,
   mockThing
 );
 
@@ -118,7 +118,7 @@ describe("Testing ThingContext matches snapshot", () => {
     jest.spyOn(SolidFns, "getThing").mockImplementation(() => mockThing);
 
     documentBody = render(
-      <DatasetProvider dataset={mockDataSetWithResourceInfo}>
+      <DatasetProvider solidDataset={mockDatasetWithResourceInfo}>
         <ThingProvider thingUrl="https://some-interesting-value.com">
           <ExampleComponentWithThingUrl />
         </ThingProvider>

--- a/src/context/thingContext/index.tsx
+++ b/src/context/thingContext/index.tsx
@@ -30,12 +30,12 @@ import { Thing, UrlString, getThing } from "@inrupt/solid-client";
 import DatasetContext from "../datasetContext";
 
 export interface IThingContext {
-  thing: Thing | undefined;
+  thing?: Thing | null;
   setThing: (thing: Thing) => void;
 }
 
 const ThingContext = createContext<IThingContext>({
-  thing: undefined,
+  thing: null,
   setThing: () => {},
 });
 
@@ -43,7 +43,7 @@ export default ThingContext;
 
 export interface IThingProvider {
   children: React.ReactNode;
-  thing?: Thing;
+  thing?: Thing | null;
   thingUrl?: UrlString | string;
 }
 
@@ -62,24 +62,24 @@ export const ThingProvider = ({
   thing: propThing,
   thingUrl,
 }: RequireThingOrThingUrl): ReactElement => {
-  const { dataset } = useContext(DatasetContext);
+  const { solidDataset } = useContext(DatasetContext);
   let thing = propThing;
 
-  if (dataset && thingUrl) {
-    thing = getThing(dataset, thingUrl) || undefined;
+  if (solidDataset && thingUrl) {
+    thing = getThing(solidDataset, thingUrl);
   }
 
   // Allow child components to update the thing
-  const [stateThing, setThing] = useState<Thing | undefined>(thing);
+  const [stateThing, setThing] = useState<Thing | null>(thing || null);
 
   // Reset the thing if the dataset changes.
   useEffect(() => {
-    if (dataset && thingUrl) {
-      setThing(getThing(dataset, thingUrl) || undefined);
+    if (solidDataset && thingUrl) {
+      setThing(getThing(solidDataset, thingUrl));
     } else if (propThing) {
       setThing(propThing);
     }
-  }, [dataset, thingUrl, propThing]);
+  }, [solidDataset, thingUrl, propThing]);
 
   return (
     <ThingContext.Provider value={{ thing: stateThing, setThing }}>

--- a/src/helpers/index.test.tsx
+++ b/src/helpers/index.test.tsx
@@ -20,7 +20,12 @@
  */
 
 import * as SolidFns from "@inrupt/solid-client";
-import { getValueByTypeAll, DataType } from ".";
+import {
+  getValueByTypeAll,
+  DataType,
+  getPropertyForThing,
+  getValueByType,
+} from "./index";
 
 describe("getValueByTypeAll", () => {
   it.each([
@@ -56,4 +61,71 @@ describe("getValueByTypeAll", () => {
       expect(mockGetter).toHaveBeenCalledTimes(1);
     }
   );
+});
+
+describe("getPropertyForThing", () => {
+  it("selects the first property with a value", () => {
+    const propertySelector = getValueByType;
+    const type = "string";
+    const mockThing = SolidFns.mockThingFrom("http://mock.thing");
+    const properties = [
+      "https://example.com/mock-prop-1",
+      "https://example.com/mock-prop-2",
+      "https://example.com/mock-prop-3",
+    ];
+
+    const thingWithString = SolidFns.setStringNoLocale(
+      mockThing,
+      properties[1],
+      "test"
+    );
+
+    expect(
+      getPropertyForThing(propertySelector, type, thingWithString, properties)
+    ).toEqual(properties[1]);
+  });
+
+  it("selects the first property if there are no matches", () => {
+    const propertySelector = getValueByType;
+    const type = "string";
+    const mockThing = SolidFns.mockThingFrom("http://mock.thing");
+    const properties = [
+      "https://example.com/mock-prop-1",
+      "https://example.com/mock-prop-2",
+      "https://example.com/mock-prop-3",
+    ];
+
+    expect(
+      getPropertyForThing(propertySelector, type, mockThing, properties)
+    ).toEqual(properties[0]);
+  });
+
+  it("selects with locale if passed", () => {
+    const propertySelector = getValueByType;
+    const type = "string";
+    const locale = "en";
+    const mockThing = SolidFns.mockThingFrom("http://mock.thing");
+    const properties = [
+      "https://example.com/mock-prop-1",
+      "https://example.com/mock-prop-2",
+      "https://example.com/mock-prop-3",
+    ];
+
+    const thingWithString = SolidFns.setStringWithLocale(
+      mockThing,
+      properties[1],
+      "test",
+      locale
+    );
+
+    expect(
+      getPropertyForThing(
+        propertySelector,
+        type,
+        thingWithString,
+        properties,
+        locale
+      )
+    ).toEqual(properties[1]);
+  });
 });

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -23,6 +23,7 @@ import {
   overwriteFile as solidOverwriteFile,
   getFile,
   Thing,
+  SolidDataset,
   UrlString,
   Url,
   getBoolean,
@@ -40,6 +41,22 @@ import {
   getStringWithLocaleAll,
   getUrlAll,
 } from "@inrupt/solid-client";
+
+import { useContext } from "react";
+
+import ThingContext from "../context/thingContext";
+import DatasetContext from "../context/datasetContext";
+
+export type CommonProperties = {
+  thing?: Thing;
+  solidDataset?: SolidDataset;
+  property?: Url | UrlString;
+  properties?: Url[] | UrlString[];
+  edit?: boolean;
+  autosave?: boolean;
+  onSave?: (savedDataset?: SolidDataset, savedThing?: Thing) => void;
+  onError?: (error: Error) => void;
+};
 
 export const overwriteFile = async (
   src: string,
@@ -94,48 +111,57 @@ export function getValueByType(
   thing: Thing,
   property: UrlString | Url
 ): ReturnType<typeof getBoolean>;
+
 export function getValueByType(
   type: "datetime",
   thing: Thing,
   property: UrlString | Url
 ): ReturnType<typeof getDatetime>;
+
 export function getValueByType(
   type: "decimal",
   thing: Thing,
   property: UrlString | Url
 ): ReturnType<typeof getDecimal>;
+
 export function getValueByType(
   type: "integer",
   thing: Thing,
   property: UrlString | Url
 ): ReturnType<typeof getInteger>;
+
 export function getValueByType(
   type: "string",
   thing: Thing,
   property: UrlString | Url
 ): ReturnType<typeof getStringNoLocale>;
+
 export function getValueByType(
   type: "string",
   thing: Thing,
   property: UrlString | Url,
   locale: string
 ): ReturnType<typeof getStringWithLocale>;
+
 export function getValueByType(
   type: "string",
   thing: Thing,
   property: UrlString | Url
 ): ReturnType<typeof getStringNoLocale>;
+
 export function getValueByType(
   type: "url",
   thing: Thing,
   property: UrlString | Url
 ): ReturnType<typeof getUrl>;
+
 export function getValueByType(
   type: DataType,
   thing: Thing,
   property: UrlString | Url,
   locale?: string
 ): string | boolean | number | Date | null;
+
 export function getValueByType(
   type: DataType,
   thing: Thing,
@@ -166,48 +192,57 @@ export function getValueByTypeAll(
   thing: Thing,
   property: UrlString | Url
 ): ReturnType<typeof getBooleanAll>;
+
 export function getValueByTypeAll(
   type: "datetime",
   thing: Thing,
   property: UrlString | Url
 ): ReturnType<typeof getDatetimeAll>;
+
 export function getValueByTypeAll(
   type: "decimal",
   thing: Thing,
   property: UrlString | Url
 ): ReturnType<typeof getDecimalAll>;
+
 export function getValueByTypeAll(
   type: "integer",
   thing: Thing,
   property: UrlString | Url
 ): ReturnType<typeof getIntegerAll>;
+
 export function getValueByTypeAll(
   type: "string",
   thing: Thing,
   property: UrlString | Url
 ): ReturnType<typeof getStringNoLocaleAll>;
+
 export function getValueByTypeAll(
   type: "string",
   thing: Thing,
   property: UrlString | Url,
   locale: string
 ): ReturnType<typeof getStringWithLocaleAll>;
+
 export function getValueByTypeAll(
   type: "string",
   thing: Thing,
   property: UrlString | Url
 ): ReturnType<typeof getStringNoLocaleAll>;
+
 export function getValueByTypeAll(
   type: "url",
   thing: Thing,
   property: UrlString | Url
 ): ReturnType<typeof getUrlAll>;
+
 export function getValueByTypeAll(
   type: DataType,
   thing: Thing,
   property: UrlString | Url,
   locale?: string
 ): Array<string | boolean | number | Date | null>;
+
 export function getValueByTypeAll(
   type: DataType,
   thing: Thing,
@@ -233,9 +268,89 @@ export function getValueByTypeAll(
   }
 }
 
-export default {
-  overwriteFile,
-  retrieveFile,
-  getValueByType,
-  getValueByTypeAll,
+export function getPropertyForThing(
+  propertySelector: typeof getValueByType | typeof getValueByTypeAll,
+  type: DataType,
+  thing: Thing,
+  properties: Array<Url | UrlString>,
+  locale?: string
+): Url | UrlString | undefined {
+  return (
+    properties.find((property: Url | UrlString) => {
+      return propertySelector(type, thing, property, locale);
+    }) || properties[0]
+  );
+}
+
+export type UseProperty = {
+  dataset?: SolidDataset;
+  thing?: Thing;
+  error?: Error;
+  property: Url | UrlString;
+  value: string | boolean | number | Date | null;
+  setDataset: (dataset: SolidDataset) => void;
+  setThing: (thing: Thing) => void;
 };
+
+export type UsePropertyProps = {
+  thing?: Thing;
+  dataset?: SolidDataset;
+  property?: Url | UrlString;
+  properties?: Url[] | UrlString[];
+  type: DataType;
+  locale?: string;
+};
+
+export function useProperty(props: UsePropertyProps): UseProperty {
+  const {
+    dataset: propDataset,
+    thing: propThing,
+    properties: propProperties,
+    property: propProperty,
+    type,
+    locale,
+  } = props;
+
+  const { solidDataset: contextDataset, setDataset = () => {} } = useContext(
+    DatasetContext
+  );
+
+  const dataset = propDataset || contextDataset;
+
+  const { thing: contextThing, setThing = () => {} } = useContext(ThingContext);
+
+  const thing = propThing || contextThing || undefined;
+  let error;
+
+  if (!thing) {
+    error = new Error("Thing not found as property or in context");
+  }
+
+  const property =
+    thing && propProperties
+      ? getPropertyForThing(
+          getValueByType,
+          type,
+          thing,
+          propProperties,
+          locale
+        ) || propProperties[0]
+      : propProperty;
+
+  if (!property) {
+    throw new Error("No property provided");
+  }
+
+  const value =
+    thing && property ? getValueByType(type, thing, property, locale) : null;
+
+  return {
+    dataset,
+    thing,
+    property,
+    error,
+    value,
+    setDataset,
+    setThing,
+  };
+}

--- a/src/hooks/useDataset/index.test.tsx
+++ b/src/hooks/useDataset/index.test.tsx
@@ -48,7 +48,7 @@ describe("useDataset() hook", () => {
     >
       <DatasetContext.Provider
         value={{
-          dataset: mockContextDataset,
+          solidDataset: mockContextDataset,
           setDataset: () => {},
         }}
       >

--- a/src/hooks/useDataset/index.tsx
+++ b/src/hooks/useDataset/index.tsx
@@ -35,7 +35,7 @@ export default function useDataset(
   error: any;
 } {
   const { fetch } = useContext(SessionContext);
-  const { dataset: datasetFromContext } = useContext(DatasetContext);
+  const { solidDataset: datasetFromContext } = useContext(DatasetContext);
   const { data, error } = useSWR(
     datasetIri ? [datasetIri, options, fetch] : null,
     () => {

--- a/src/hooks/useThing/index.test.tsx
+++ b/src/hooks/useThing/index.test.tsx
@@ -79,7 +79,7 @@ describe("useThing() hook", () => {
     );
 
     expect(mockGetThing).toHaveBeenCalledTimes(0);
-    await waitFor(() => expect(result.current.thing).toBeUndefined());
+    await waitFor(() => expect(result.current.thing).toBeNull());
   });
 
   it("should return any error returned by useDataset", async () => {

--- a/src/hooks/useThing/index.tsx
+++ b/src/hooks/useThing/index.tsx
@@ -30,17 +30,17 @@ export default function useThing(
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
   options?: any
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): { thing: Thing | undefined; error: any } {
+): { thing?: Thing | null; error: any } {
   const { dataset, error } = useDataset(datasetIri, options);
   const { thing: thingFromContext } = useContext(ThingContext);
   if (!thingIri) {
-    return { thing: thingFromContext, error };
+    return { thing: thingFromContext || undefined, error };
   }
 
   if (!dataset) {
-    return { thing: undefined, error };
+    return { thing: null, error };
   }
 
-  const thing = getThing(dataset, thingIri) || undefined;
+  const thing = getThing(dataset, thingIri);
   return { thing, error };
 }

--- a/stories/components/image.stories.tsx
+++ b/stories/components/image.stories.tsx
@@ -36,8 +36,11 @@ export default {
       control: { type: null },
     },
     property: {
-      type: { required: true },
       description: `The property of the [Thing](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/glossary/#term-Thing) to retrieve the src URL from.`,
+      control: { type: null },
+    },
+    properties: {
+      description: `An array of ordered properties that will be used to attempt to read the src from (see \`property\`). If there is no value at the first property, the second is attempted, etc, and used for both reading and writing.`,
       control: { type: null },
     },
     edit: {
@@ -79,6 +82,19 @@ export function BasicExample(): ReactElement {
 }
 
 BasicExample.parameters = {
+  actions: { disable: true },
+  controls: { disable: true },
+};
+
+export function PropertyArrayExample(): ReactElement {
+  const property = "http://schema.org/contentUrl";
+  const notFoundProperty = "http://schema.org/iri-not-on-the-thing";
+  const thing = addUrl(createThing(), property, `${host}/example.jpg`);
+
+  return <Image thing={thing} properties={[notFoundProperty, property]} />;
+}
+
+PropertyArrayExample.parameters = {
   actions: { disable: true },
   controls: { disable: true },
 };

--- a/stories/components/link.stories.tsx
+++ b/stories/components/link.stories.tsx
@@ -80,3 +80,34 @@ WithoutChildren.parameters = {
 WithoutChildren.args = {
   property: "http://xmlns.com/foaf/0.1/homepage",
 };
+
+export function Editable({ property }: { property: string }): ReactElement {
+  const exampleUrl = "http://test.url";
+  const exampleThing = SolidFns.addUrl(
+    SolidFns.createThing(),
+    property,
+    exampleUrl
+  );
+
+  const exampleDataset = SolidFns.setThing(
+    SolidFns.createSolidDataset(),
+    exampleThing
+  );
+
+  return (
+    <Link
+      thing={exampleThing}
+      property={property}
+      solidDataset={exampleDataset}
+      edit
+    />
+  );
+}
+
+Editable.parameters = {
+  actions: { disable: true },
+};
+
+Editable.args = {
+  property: "http://xmlns.com/foaf/0.1/homepage",
+};

--- a/stories/components/table.stories.tsx
+++ b/stories/components/table.stories.tsx
@@ -268,13 +268,16 @@ export function NestedDataExample(): ReactElement {
 
   const NestedDataExampleContent = () => {
     const datasetContext = useContext(DatasetContext);
-    const { dataset } = datasetContext;
-    if (!dataset) {
+    const { solidDataset } = datasetContext;
+    if (!solidDataset) {
       return null;
     }
-    const personThing = SolidFns.getThing(dataset, `${host}/example.ttl#me`);
+    const personThing = SolidFns.getThing(
+      solidDataset,
+      `${host}/example.ttl#me`
+    );
     const alterEgoThing = SolidFns.getThing(
-      dataset,
+      solidDataset,
       `${host}/example.ttl#alterEgo`
     );
     if (!personThing || !alterEgoThing) {
@@ -284,11 +287,11 @@ export function NestedDataExample(): ReactElement {
       <Table
         things={[
           {
-            dataset,
+            dataset: solidDataset,
             thing: personThing,
           },
           {
-            dataset,
+            dataset: solidDataset,
             thing: alterEgoThing,
           },
         ]}
@@ -303,7 +306,7 @@ export function NestedDataExample(): ReactElement {
           body={({ value }) => (
             <PhoneNumberDisplay
               numberThingIris={value}
-              dataset={dataset}
+              dataset={solidDataset}
               numberType={homeProperty}
             />
           )}
@@ -316,7 +319,7 @@ export function NestedDataExample(): ReactElement {
           body={({ value }) => (
             <PhoneNumberDisplay
               numberThingIris={value}
-              dataset={dataset}
+              dataset={solidDataset}
               numberType={workProperty}
             />
           )}

--- a/stories/components/text.stories.tsx
+++ b/stories/components/text.stories.tsx
@@ -43,7 +43,7 @@ export default {
     thing: {
       description: `The [Thing](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/glossary/#term-Thing) to retrieve the text from. Uses a Thing from context if not supplied.`,
     },
-    dataSet: {
+    dataset: {
       description: `The [Dataset](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/glossary/#term-SolidDataset) to retrieve the text from. Uses a Dataset from context if not supplied.`,
     },
     property: {
@@ -103,14 +103,14 @@ export function BasicExample({
     exampleNick
   );
 
-  const exampleDataSet = SolidFns.setThing(
+  const exampleDataset = SolidFns.setThing(
     SolidFns.createSolidDataset(),
     exampleThing
   );
 
   return (
     <Text
-      dataSet={exampleDataSet}
+      solidDataset={exampleDataset}
       thing={exampleThing}
       property={property}
       autosave={autosave}
@@ -145,14 +145,14 @@ export function WithLocalData({
     exampleNick
   );
 
-  const exampleDataSet = SolidFns.setThing(
+  const exampleDataset = SolidFns.setThing(
     SolidFns.createSolidDataset(),
     exampleThing
   );
 
   return (
     <Text
-      dataSet={exampleDataSet}
+      solidDataset={exampleDataset}
       thing={exampleThing}
       property={examplePredicate}
       edit={edit}

--- a/stories/components/value.stories.tsx
+++ b/stories/components/value.stories.tsx
@@ -68,7 +68,7 @@ export default {
     thing: {
       description: `The [Thing](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/glossary/#term-Thing) to retrieve the value from. Uses a Thing from context if not supplied.`,
     },
-    dataSet: {
+    dataset: {
       description: `The [Dataset](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/glossary/#term-SolidDataset) to retrieve the value from. Uses a Dataset from context if not supplied.`,
     },
     property: {
@@ -354,7 +354,7 @@ export function WithUnsavedData(
     exampleNick
   );
 
-  const exampleDataSet = SolidFns.setThing(
+  const exampleDataset = SolidFns.setThing(
     SolidFns.createSolidDataset(),
     exampleThing
   );
@@ -362,7 +362,7 @@ export function WithUnsavedData(
   return (
     <Value
       dataType="string"
-      dataSet={exampleDataSet}
+      solidDataset={exampleDataset}
       thing={exampleThing}
       property={property}
       edit={edit}

--- a/stories/providers/combinedProvider.stories.tsx
+++ b/stories/providers/combinedProvider.stories.tsx
@@ -71,13 +71,13 @@ export function WithLocalData(): ReactElement {
     property,
     name
   );
-  const dataSet = SolidFns.setThing(
+  const dataset = SolidFns.setThing(
     SolidFns.createSolidDataset(),
     exampleThing
   );
 
   return (
-    <CombinedDataProvider dataset={dataSet} thing={exampleThing}>
+    <CombinedDataProvider solidDataset={dataset} thing={exampleThing}>
       <ExampleComponent propertyUrl={property} />
     </CombinedDataProvider>
   );

--- a/stories/providers/datasetProvider.stories.tsx
+++ b/stories/providers/datasetProvider.stories.tsx
@@ -61,13 +61,13 @@ export function WithLocalDataset(): ReactElement {
     property,
     name
   );
-  const dataSet = SolidFns.setThing(
+  const dataset = SolidFns.setThing(
     SolidFns.createSolidDataset(),
     exampleThing
   );
 
   return (
-    <DatasetProvider dataset={dataSet}>
+    <DatasetProvider solidDataset={dataset}>
       <ExampleComponentWithDataset />
     </DatasetProvider>
   );
@@ -118,14 +118,14 @@ function ExampleComponentWithDatasetUrl(
   const [property, setProperty] = useState<string>("fetching in progress");
 
   const datasetContext = useContext(DatasetContext);
-  const { dataset } = datasetContext;
+  const { solidDataset } = datasetContext;
 
   useEffect(() => {
-    if (dataset) {
-      const thing = SolidFns.getThing(dataset, thingUrl);
+    if (solidDataset) {
+      const thing = SolidFns.getThing(solidDataset, thingUrl);
       setExampleThing(thing || undefined);
     }
-  }, [dataset, thingUrl]);
+  }, [solidDataset, thingUrl]);
 
   useEffect(() => {
     if (exampleThing) {
@@ -151,14 +151,14 @@ function ExampleComponentWithDataset(): ReactElement {
   const [property, setProperty] = useState<string>("fetching in progress");
 
   const datasetContext = useContext(DatasetContext);
-  const { dataset } = datasetContext;
+  const { solidDataset } = datasetContext;
 
   useEffect(() => {
-    if (dataset) {
-      const things = SolidFns.getThingAll(dataset);
+    if (solidDataset) {
+      const things = SolidFns.getThingAll(solidDataset);
       setExampleThing(things[0]);
     }
-  }, [dataset]);
+  }, [solidDataset]);
 
   useEffect(() => {
     if (exampleThing) {

--- a/stories/providers/thingProvider.stories.tsx
+++ b/stories/providers/thingProvider.stories.tsx
@@ -91,7 +91,7 @@ export function WithThingUrl(props: IWithThingUrl): ReactElement {
 
   if (litDataset) {
     return (
-      <DatasetProvider dataset={litDataset}>
+      <DatasetProvider solidDataset={litDataset}>
         <ThingProvider thingUrl={thingUrl}>
           <ExampleComponentWithThingUrl property={property} />
         </ThingProvider>


### PR DESCRIPTION
## 2.0.0 ( November 6, 2020 )

### BREAKING

- `dataset` property replaced by `solidDataset` in components so that the property would not
  conflict with intrisic HTML element attributes.
- Components such as `text` and `value` no longer throw errors if something goes wrong during
  reading or saving, and instead always call `onError` if provided.

### Added

- All components which previously took a `property` prop now can optionally accept a
  `properties` prop instead, which will be an ordered list of properties to attempt to read and
  write from. If none of the properties have values, the first will be used if editing data.


# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
