### PR TITLE
Don't fail CD runs on Dependabot PRs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     outputs:
       tag-slug: ${{ steps.determine-npm-tag.outputs.tag-slug }}
-      deployment-id: ${{ fromJson(steps.create-deployment.outputs.data).id }}
+      deployment-id: ${{ fromJson(steps.create-deployment.outputs.data || '{}').id || 'Skipped for Dependabot' }}
     steps:
     - name: Create GitHub Deployment
       if: github.actor != 'dependabot[bot]'


### PR DESCRIPTION
It's trying to pass some data as job output, but since that job doesn't run on Dependabot PRs (because it needs access to the repo secrets), that step would fail.