### PR TITLE
Fix: handle datetime-local not supported by browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following sections document changes that have been released already:
 
-## 2.3.0 ( May 31, 2021 )
+### Bugs fixed
+
+- The `Value` component now handles the case where `datetime-local` is unsupported by the browser and renders two inputs with type `date` and `time` instead. 
 
 ### Changed
 

--- a/src/components/value/__snapshots__/index.test.tsx.snap
+++ b/src/components/value/__snapshots__/index.test.tsx.snap
@@ -33,6 +33,7 @@ exports[`<Value /> component snapshot test matches snapshot with dataType dateti
   />
   <input
     aria-label="Time"
+    pattern="[0-9]{2}:[0-9]{2}"
     type="time"
     value="06:00:00"
   />

--- a/src/components/value/__snapshots__/index.test.tsx.snap
+++ b/src/components/value/__snapshots__/index.test.tsx.snap
@@ -24,13 +24,15 @@ exports[`<Value /> component snapshot test matches snapshot with data from conte
 exports[`<Value /> component snapshot test matches snapshot with dataType datetime when browser does not support datetime-local 1`] = `
 <DocumentFragment>
   <input
-    pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}"
-    placeholder="yyyy-mm-ddThh:mm"
+    aria-label="Date"
+    pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}"
+    placeholder="yyyy-mm-dd"
     step="any"
     type="date"
     value="2021-05-04"
   />
   <input
+    aria-label="Time"
     type="time"
     value="06:00:00"
   />

--- a/src/components/value/__snapshots__/index.test.tsx.snap
+++ b/src/components/value/__snapshots__/index.test.tsx.snap
@@ -21,6 +21,34 @@ exports[`<Value /> component snapshot test matches snapshot with data from conte
 </body>
 `;
 
+exports[`<Value /> component snapshot test matches snapshot with dataType datetime when browser does not support datetime-local 1`] = `
+<DocumentFragment>
+  <input
+    pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}"
+    placeholder="yyyy-mm-ddThh:mm"
+    step="any"
+    type="date"
+    value="2021-05-04"
+  />
+  <input
+    type="time"
+    value="06:00:00"
+  />
+</DocumentFragment>
+`;
+
+exports[`<Value /> component snapshot test matches snapshot with dataType datetime when browser supports datetime-local 1`] = `
+<DocumentFragment>
+  <input
+    pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}"
+    placeholder="yyyy-mm-ddThh:mm"
+    step="any"
+    type="datetime-local"
+    value="2021-05-04T06:00:00"
+  />
+</DocumentFragment>
+`;
+
 exports[`<Value /> component snapshot test matches snapshot with edit true and inputOptions 1`] = `
 <body>
   <div>

--- a/src/components/value/index.test.tsx
+++ b/src/components/value/index.test.tsx
@@ -61,7 +61,7 @@ const inputOptions = {
 };
 
 const mockDatasetWithBdayResourceInfo = SolidFns.setThing(
-  SolidFns.createSolidDataset() as any,
+  SolidFns.createSolidDataset(),
   mockThingWithBday
 );
 
@@ -125,7 +125,7 @@ describe("<Value /> component snapshot test", () => {
   });
 
   it("matches snapshot with dataType datetime when browser does not support datetime-local", () => {
-    jest.spyOn(helpers, "UseDatetimeBrowserSupport").mockReturnValueOnce(false);
+    jest.spyOn(helpers, "useDatetimeBrowserSupport").mockReturnValueOnce(false);
     const { asFragment } = render(
       <Value
         dataType="datetime"
@@ -235,17 +235,15 @@ describe("<Value /> component functional testing", () => {
     }
   );
 
-  it("when dataType is datetime and datetime-local is unssuported, it calls the setDatetime with the correct value", () => {
-    jest.spyOn(helpers, "UseDatetimeBrowserSupport").mockReturnValue(false);
+  it("when dataType is datetime and datetime-local is unsupported, it calls the setDatetime with the correct value", () => {
+    jest.spyOn(helpers, "useDatetimeBrowserSupport").mockReturnValue(false);
     jest.spyOn(SolidFns, "getDatetime").mockImplementationOnce(() => null);
 
-    const mockSetter = jest
-      .spyOn(SolidFns, "setDatetime")
-      .mockImplementation(() => mockThing);
+    const mockSetter = jest.spyOn(SolidFns, "setDatetime");
 
     jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataset);
 
-    const { getByTitle } = render(
+    const { getByLabelText } = render(
       <Value
         dataType="datetime"
         solidDataset={mockDatasetWithBdayResourceInfo}
@@ -253,14 +251,22 @@ describe("<Value /> component functional testing", () => {
         property={mockBdayPredicate}
         edit
         autosave
-        inputProps={{ title: "test title" }}
       />
     );
-    const input = getByTitle("test title");
-    input.focus();
-    fireEvent.change(input, { target: { value: "2020-12-30T12:30" } });
-    input.blur();
-    expect(mockSetter).toHaveBeenCalled();
+    const dateInput = getByLabelText("Date");
+    dateInput.focus();
+    fireEvent.change(dateInput, { target: { value: "2020-03-03" } });
+    dateInput.blur();
+    const timeInput = getByLabelText("Time");
+    timeInput.focus();
+    fireEvent.change(timeInput, { target: { value: "05:45" } });
+    timeInput.blur();
+    const expectedDate = new Date(Date.UTC(2020, 2, 3, 0, 0, 0));
+    const expectedDateAndTime = new Date(Date.UTC(2020, 2, 3, 5, 45, 0));
+    expect(mockSetter.mock.calls).toEqual([
+      [mockThing, mockBdayPredicate, expectedDate],
+      [mockThing, mockBdayPredicate, expectedDateAndTime],
+    ]);
   });
 
   it("Should not call setter on blur if the value of the input hasn't changed", async () => {

--- a/src/components/value/index.tsx
+++ b/src/components/value/index.tsx
@@ -41,7 +41,7 @@ import {
   DataType,
   CommonProperties,
   useProperty,
-  UseDatetimeBrowserSupport,
+  useDatetimeBrowserSupport,
 } from "../../helpers";
 
 export type Props = {
@@ -88,7 +88,7 @@ export function Value({
     locale,
   });
 
-  const isDatetimeSupported = UseDatetimeBrowserSupport();
+  const isDatetimeSupported = useDatetimeBrowserSupport();
 
   useEffect(() => {
     if (error && onError) {
@@ -109,13 +109,13 @@ export function Value({
           .substring(0, (thingValue as Date).toISOString().length - 5)
       : null;
   } else if (dataType !== "string") {
-    formattedValue = thingValue?.toString() || "";
+    formattedValue = thingValue?.toString() ?? "";
   }
 
   const [value, setValue] = useState<string>(formattedValue as string);
 
   const [booleanValue, setBooleanValue] = useState<boolean>(
-    initialBooleanValue as boolean
+    initialBooleanValue
   );
 
   useEffect(() => {
@@ -142,12 +142,12 @@ export function Value({
     initialTimeValue = value?.split(/T(.+)/)[1].toString();
   }
 
-  const [time, setTime] = useState<string>(initialTimeValue as string);
-  const [date, setDate] = useState<string>(initialDateValue as string);
+  const [time, setTime] = useState<string>(initialTimeValue);
+  const [date, setDate] = useState<string>(initialDateValue);
 
   useEffect(() => {
     if ((!time && !date) || dataType !== "datetime") return;
-    setValue(`${date || ""}T${time || "00:00"}`);
+    setValue(`${date ?? ""}T${time ?? "00:00"}`);
   }, [time, date, dataType]);
 
   /* Save Value value in the pod */
@@ -163,11 +163,7 @@ export function Value({
 
       switch (dataType) {
         case "boolean":
-          updatedResource = setBoolean(
-            thing,
-            property,
-            booleanValue as boolean
-          );
+          updatedResource = setBoolean(thing, property, booleanValue);
           break;
         case "datetime":
           updatedResource = setDatetime(
@@ -254,7 +250,7 @@ export function Value({
     return <span>fetching data in progress</span>;
   }
 
-  let inputType: string | undefined;
+  let inputType: string;
   let inputStep;
 
   switch (dataType) {
@@ -262,7 +258,9 @@ export function Value({
       inputType = "checkbox";
       break;
     case "datetime":
-      inputType = isDatetimeSupported ? "datetime-local" : "date";
+      inputType = isDatetimeSupported
+        ? "datetime-local"
+        : "datetime-workaround";
       inputStep = "any";
       break;
     case "decimal":
@@ -285,7 +283,7 @@ export function Value({
         // eslint-disable-next-line react/jsx-props-no-spreading
         !edit && dataset && thing && <span {...other}>{`${value}`}</span>
       }
-      {edit && dataset && thing && inputType !== "date" && (
+      {edit && dataset && thing && inputType !== "datetime-workaround" && (
         <input
           type={inputType}
           checked={booleanValue}
@@ -309,10 +307,11 @@ export function Value({
           placeholder={dataType === "datetime" ? "yyyy-mm-ddThh:mm" : undefined}
         />
       )}
-      {edit && dataset && thing && inputType === "date" && (
+      {edit && dataset && thing && inputType === "datetime-workaround" && (
         <>
           <input
-            type={inputType}
+            type="date"
+            aria-label="Date"
             step={inputStep}
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...inputProps}
@@ -321,11 +320,12 @@ export function Value({
             }}
             onBlur={(e) => autosave && saveHandler(e)}
             value={date}
-            pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}"
-            placeholder="yyyy-mm-ddThh:mm"
+            pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}"
+            placeholder="yyyy-mm-dd"
           />
           <input
             type="time"
+            aria-label="Time"
             value={time}
             onChange={(e) => setTime(e.target.value)}
             onBlur={(e) => autosave && saveHandler(e)}

--- a/src/components/value/index.tsx
+++ b/src/components/value/index.tsx
@@ -139,7 +139,7 @@ export function Value({
     !isDatetimeSupported &&
     typeof value === "string"
   ) {
-    initialTimeValue = value?.split(/T(.+)/)[1].toString();
+    initialTimeValue = value?.split(/T(.+)/)[1]?.toString();
   }
 
   const [time, setTime] = useState<string>(initialTimeValue);
@@ -329,6 +329,7 @@ export function Value({
             value={time}
             onChange={(e) => setTime(e.target.value)}
             onBlur={(e) => autosave && saveHandler(e)}
+            pattern="[0-9]{2}:[0-9]{2}"
           />
         </>
       )}

--- a/src/components/value/index.tsx
+++ b/src/components/value/index.tsx
@@ -37,7 +37,12 @@ import {
 } from "@inrupt/solid-client";
 import { SessionContext } from "../../context/sessionContext";
 
-import { DataType, CommonProperties, useProperty } from "../../helpers";
+import {
+  DataType,
+  CommonProperties,
+  useProperty,
+  UseDatetimeBrowserSupport,
+} from "../../helpers";
 
 export type Props = {
   dataType: DataType;
@@ -83,6 +88,8 @@ export function Value({
     locale,
   });
 
+  const isDatetimeSupported = UseDatetimeBrowserSupport();
+
   useEffect(() => {
     if (error && onError) {
       onError(error);
@@ -90,20 +97,58 @@ export function Value({
   }, [error, onError]);
 
   let formattedValue = thingValue;
+  let initialBooleanValue = false;
 
   if (dataType === "boolean") {
-    formattedValue = (thingValue as boolean | null) ?? false;
+    initialBooleanValue = (thingValue as boolean | null) ?? false;
+    formattedValue = initialBooleanValue.toString();
   } else if (dataType === "datetime") {
     formattedValue = thingValue
       ? (thingValue as Date)
           .toISOString()
           .substring(0, (thingValue as Date).toISOString().length - 5)
       : null;
+  } else if (dataType !== "string") {
+    formattedValue = thingValue?.toString() || "";
   }
 
-  const [value, setValue] = useState<string | number | boolean | null>(
-    formattedValue as string | number | boolean | null
+  const [value, setValue] = useState<string>(formattedValue as string);
+
+  const [booleanValue, setBooleanValue] = useState<boolean>(
+    initialBooleanValue as boolean
   );
+
+  useEffect(() => {
+    if (dataType === "boolean") {
+      setValue(booleanValue.toString());
+    }
+  }, [booleanValue, dataType]);
+
+  let initialDateValue = "";
+  if (
+    dataType === "datetime" &&
+    !isDatetimeSupported &&
+    typeof value === "string"
+  ) {
+    initialDateValue = value?.split(/T(.+)/)[0].toString();
+  }
+
+  let initialTimeValue = "00:00";
+  if (
+    dataType === "datetime" &&
+    !isDatetimeSupported &&
+    typeof value === "string"
+  ) {
+    initialTimeValue = value?.split(/T(.+)/)[1].toString();
+  }
+
+  const [time, setTime] = useState<string>(initialTimeValue as string);
+  const [date, setDate] = useState<string>(initialDateValue as string);
+
+  useEffect(() => {
+    if ((!time && !date) || dataType !== "datetime") return;
+    setValue(`${date || ""}T${time || "00:00"}`);
+  }, [time, date, dataType]);
 
   /* Save Value value in the pod */
   const saveHandler = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -114,13 +159,22 @@ export function Value({
       e.target.reportValidity()
     ) {
       let updatedResource = thing;
+      const datetimeValue = value;
 
       switch (dataType) {
         case "boolean":
-          updatedResource = setBoolean(thing, property, value as boolean);
+          updatedResource = setBoolean(
+            thing,
+            property,
+            booleanValue as boolean
+          );
           break;
         case "datetime":
-          updatedResource = setDatetime(thing, property, new Date(`${value}Z`));
+          updatedResource = setDatetime(
+            thing,
+            property,
+            new Date(`${datetimeValue}Z`)
+          );
           break;
         case "decimal": {
           updatedResource = setDecimal(
@@ -200,7 +254,7 @@ export function Value({
     return <span>fetching data in progress</span>;
   }
 
-  let inputType;
+  let inputType: string | undefined;
   let inputStep;
 
   switch (dataType) {
@@ -208,7 +262,7 @@ export function Value({
       inputType = "checkbox";
       break;
     case "datetime":
-      inputType = "datetime-local";
+      inputType = isDatetimeSupported ? "datetime-local" : "date";
       inputStep = "any";
       break;
     case "decimal":
@@ -231,30 +285,22 @@ export function Value({
         // eslint-disable-next-line react/jsx-props-no-spreading
         !edit && dataset && thing && <span {...other}>{`${value}`}</span>
       }
-      {edit && dataset && thing && (
+      {edit && dataset && thing && inputType !== "date" && (
         <input
           type={inputType}
-          checked={
-            dataType === "boolean" && typeof value === "boolean"
-              ? value
-              : undefined
-          }
+          checked={booleanValue}
           step={inputStep}
           // eslint-disable-next-line react/jsx-props-no-spreading
           {...inputProps}
           onChange={(e) => {
             if (dataType === "boolean") {
-              setValue(e.target.checked);
+              setBooleanValue(e.target.checked);
             } else {
               setValue(e.target.value);
             }
           }}
           onBlur={(e) => autosave && saveHandler(e)}
-          value={
-            dataType !== "boolean" && typeof value !== "boolean"
-              ? value || ""
-              : "on"
-          }
+          value={value}
           pattern={
             dataType === "datetime"
               ? "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}"
@@ -262,6 +308,29 @@ export function Value({
           }
           placeholder={dataType === "datetime" ? "yyyy-mm-ddThh:mm" : undefined}
         />
+      )}
+      {edit && dataset && thing && inputType === "date" && (
+        <>
+          <input
+            type={inputType}
+            step={inputStep}
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...inputProps}
+            onChange={(e) => {
+              setDate(e.target.value);
+            }}
+            onBlur={(e) => autosave && saveHandler(e)}
+            value={date}
+            pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}"
+            placeholder="yyyy-mm-ddThh:mm"
+          />
+          <input
+            type="time"
+            value={time}
+            onChange={(e) => setTime(e.target.value)}
+            onBlur={(e) => autosave && saveHandler(e)}
+          />
+        </>
       )}
     </>
   );

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -42,7 +42,7 @@ import {
   getUrlAll,
 } from "@inrupt/solid-client";
 
-import { useContext } from "react";
+import { useContext, useEffect, useState } from "react";
 
 import ThingContext from "../context/thingContext";
 import DatasetContext from "../context/datasetContext";
@@ -353,4 +353,22 @@ export function useProperty(props: UsePropertyProps): UseProperty {
     setDataset,
     setThing,
   };
+}
+
+export function UseDatetimeBrowserSupport(): boolean | null {
+  const [isDatetimeSupported, setIsDatetimeSupported] = useState<
+    boolean | null
+  >(null);
+
+  useEffect(() => {
+    const test = document.createElement("input");
+    test.type = "datetime-local";
+    if (test.type === "text") {
+      setIsDatetimeSupported(false as boolean);
+    } else {
+      setIsDatetimeSupported(true as boolean);
+    }
+  }, []);
+
+  return isDatetimeSupported;
 }

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -355,7 +355,7 @@ export function useProperty(props: UsePropertyProps): UseProperty {
   };
 }
 
-export function UseDatetimeBrowserSupport(): boolean | null {
+export function useDatetimeBrowserSupport(): boolean | null {
   const [isDatetimeSupported, setIsDatetimeSupported] = useState<
     boolean | null
   >(null);
@@ -363,11 +363,7 @@ export function UseDatetimeBrowserSupport(): boolean | null {
   useEffect(() => {
     const test = document.createElement("input");
     test.type = "datetime-local";
-    if (test.type === "text") {
-      setIsDatetimeSupported(false as boolean);
-    } else {
-      setIsDatetimeSupported(true as boolean);
-    }
+    setIsDatetimeSupported(test.type !== "text");
   }, []);
 
   return isDatetimeSupported;


### PR DESCRIPTION
This PR introduces changes to the `Value` component to better handle the case where `datetime-local` is not supported by the browser by rendering two inputs with type `date` and `time`.

- handle case where `datetime-local` is not supported by browser

- simplify value state to use strings to keep inputs controlled

- add tests

<!-- When fixing a bug: -->

This PR fixes #SDK-2041

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

<!-- When adding a new feature: -->

# New feature description

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [ ] New functions/types have been exported in `index.ts`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

<!-- When cutting a release: -->

This PR bumps the version to <version number>.

# Checklist

- [ ] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
- [ ] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [ ] `@since X.Y.Z` annotations have been added to new APIs.
- [ ] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [ ] I will make sure **not** to squash these commits, but **rebase** instead.
- [ ] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
