### PR TITLE
Release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+The following sections document changes that have been released already:
+
+## 2.3.0 ( May 31, 2021 )
+
 ### Changed
 
 - The `SessionProvider` component now accepts additional variables to enable
 logging back in on refresh. 
-
-The following sections document changes that have been released already:
 
 ## 2.2.0 ( May 19, 2021 )
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-ui-react",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-ui-react",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Set of UI libraries using @solid/core",
   "main": "dist/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/context/sessionContext/index.tsx
+++ b/src/context/sessionContext/index.tsx
@@ -65,7 +65,9 @@ export interface ISessionProvider {
   session?: Session;
   sessionRequestInProgress?: boolean;
   onError?: (error: Error) => void;
+  /** @since 2.3.0 */
   restorePreviousSession?: boolean;
+  /** @since 2.3.0 */
   onSessionRestore?: (url: string) => void;
 }
 


### PR DESCRIPTION
This PR bumps the version to 2.3.0.

/cc @Falx this will release what you asked for in #338.

# Checklist

- [x] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
- [x] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [x] `@since X.Y.Z` annotations have been added to new APIs.
- [x] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [x] I will make sure **not** to squash these commits, but **rebase** instead.
- [x] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
