### PR TITLE
Fix: set session restore callback only when it changes

### DIFF
--- a/src/context/sessionContext/index.tsx
+++ b/src/context/sessionContext/index.tsx
@@ -82,12 +82,15 @@ export const SessionProvider = ({
   restorePreviousSession,
   onSessionRestore,
 }: ISessionProvider): ReactElement => {
+  const [restoreSession, setRestoreSession] = useState(restorePreviousSession);
   const [session, setSession] = useState<Session>(getDefaultSession());
-  let restoreSession = restorePreviousSession;
-  if (onSessionRestore !== undefined) {
-    onSessionRestoreClient(onSessionRestore);
-    restoreSession = true;
-  }
+
+  useEffect(() => {
+    if (onSessionRestore !== undefined) {
+      onSessionRestoreClient(onSessionRestore);
+      setRestoreSession(true);
+    }
+  }, [onSessionRestore]);
 
   const defaultInProgress =
     typeof defaultSessionRequestInProgress === "undefined"
@@ -104,8 +107,13 @@ export const SessionProvider = ({
   if (typeof window !== "undefined") {
     currentLocation = window.location;
   }
-
   useEffect(() => {
+    if (
+      typeof restoreSession === "undefined" &&
+      typeof onSessionRestore !== "undefined"
+    ) {
+      return;
+    }
     handleIncomingRedirect({
       url: window.location.href,
       restorePreviousSession: restoreSession,
@@ -126,7 +134,14 @@ export const SessionProvider = ({
       // TODO force a refresh
       setSession(getDefaultSession());
     });
-  }, [session, sessionId, onError, currentLocation, restoreSession]);
+  }, [
+    session,
+    sessionId,
+    onError,
+    currentLocation,
+    restoreSession,
+    onSessionRestore,
+  ]);
 
   const contextLogin = async (options: ILoginInputOptions) => {
     setSessionRequestInProgress(true);

--- a/src/context/sessionContext/index.tsx
+++ b/src/context/sessionContext/index.tsx
@@ -128,14 +128,7 @@ export const SessionProvider = ({
       // TODO force a refresh
       setSession(getDefaultSession());
     });
-  }, [
-    session,
-    sessionId,
-    onError,
-    currentLocation,
-    restoreSession,
-    onSessionRestore,
-  ]);
+  }, [session, sessionId, onError, currentLocation, restoreSession]);
 
   const contextLogin = async (options: ILoginInputOptions) => {
     setSessionRequestInProgress(true);

--- a/src/context/sessionContext/index.tsx
+++ b/src/context/sessionContext/index.tsx
@@ -82,13 +82,13 @@ export const SessionProvider = ({
   restorePreviousSession,
   onSessionRestore,
 }: ISessionProvider): ReactElement => {
-  const [restoreSession, setRestoreSession] = useState(restorePreviousSession);
+  const restoreSession =
+    restorePreviousSession || typeof onSessionRestore !== "undefined";
   const [session, setSession] = useState<Session>(getDefaultSession());
 
   useEffect(() => {
     if (onSessionRestore !== undefined) {
       onSessionRestoreClient(onSessionRestore);
-      setRestoreSession(true);
     }
   }, [onSessionRestore]);
 
@@ -108,12 +108,6 @@ export const SessionProvider = ({
     currentLocation = window.location;
   }
   useEffect(() => {
-    if (
-      typeof restoreSession === "undefined" &&
-      typeof onSessionRestore !== "undefined"
-    ) {
-      return;
-    }
     handleIncomingRedirect({
       url: window.location.href,
       restorePreviousSession: restoreSession,


### PR DESCRIPTION
This PR fixes #SDK-2059:

- Set session restore callback only when it changes instead of on every render
- Add test

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
