### PR TITLE
Feat: standardize loading and error messages across components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+- The following components now take an optional `loadingComponent` to be rendered while fetching data:
+  - `Value`
+  - `Text`
+  - `Link`
+  - `Image`
+  - `Video`
+- When these are not passed, the components render a default message instead. 
+
+- The following components now take an optional `errorComponent` to be rendered in case of error:
+  - `Value`
+  - `Text`
+  - `Link`
+- When these are not passed, the components render a default message instead. 
+
 The following sections document changes that have been released already:
 
 ## 2.3.1 ( June 9, 2021 )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,19 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   - `Link`
   - `Image`
   - `Video`
-- When these are not passed, the components render a default message instead. 
+- When it is not passed, the components render a default message instead. 
+- If `null`, the default message won't be rendered.
 
 - The following components now take an optional `errorComponent` to be rendered in case of error:
   - `Value`
   - `Text`
   - `Link`
-- When these are not passed, the components render a default message instead. 
+- When it is not passed, the components render a default message instead. 
+- `DatasetProvider` still receives this now as `loadingComponent`.
+- `CombinedProvider` now receives this prop and passes it down to the `DatasetProvider`.
 
-- `loading` changed to `loadingComponent` in `DatasetProvider` to match the rest of the components
-- `CombinedProvider` now receives this prop and passes it down to the `DatasetProvider`
+## Deprecations
+- `loading` in `DatasetProvider` is now deprecated and replaced with `loadingComponent` in to match the rest of the components. `loading` can still be used in `DatasetProvider` but may be removed in a future major release.
 
 The following sections document changes that have been released already:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - `CombinedProvider` now receives this prop and passes it down to the `DatasetProvider`.
 
 ## Deprecations
-- `loading` in `DatasetProvider` is now deprecated and replaced with `loadingComponent` in to match the rest of the components. `loading` can still be used in `DatasetProvider` but may be removed in a future major release.
+- `loading` in `DatasetProvider` is now deprecated and replaced with `loadingComponent` to match the rest of the components. `loading` can still be used in `DatasetProvider` but may be removed in a future major release.
 
 The following sections document changes that have been released already:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   - `Link`
 - When these are not passed, the components render a default message instead. 
 
+- `loading` changed to `loadingComponent` in `DatasetProvider` to match the rest of the components
+- `CombinedProvider` now receives this prop and passes it down to the `DatasetProvider`
+
 The following sections document changes that have been released already:
 
 ## 2.3.1 ( June 9, 2021 )

--- a/src/components/image/__snapshots__/index.test.tsx.snap
+++ b/src/components/image/__snapshots__/index.test.tsx.snap
@@ -8,6 +8,8 @@ exports[`Image component Image functional tests When getUrl returns null, with a
 </DocumentFragment>
 `;
 
+exports[`Image component Image snapshots does not render default loading message if loadingComponent is null 1`] = `<DocumentFragment />`;
+
 exports[`Image component Image snapshots matches snapshot with additional props for img and input 1`] = `
 <DocumentFragment>
   <img

--- a/src/components/image/__snapshots__/index.test.tsx.snap
+++ b/src/components/image/__snapshots__/index.test.tsx.snap
@@ -34,8 +34,36 @@ exports[`Image component Image snapshots matches snapshot with standard props 1`
 
 exports[`Image component Image snapshots renders an error message if an errorComponent is provided 1`] = `
 <DocumentFragment>
+  <span
+    id="custom-error-component"
+  >
+    Error: No value found for property.
+  </span>
+</DocumentFragment>
+`;
+
+exports[`Image component Image snapshots renders default error message if there is an error and no errorComponent is passed 1`] = `
+<DocumentFragment>
   <span>
     Error: No value found for property.
+  </span>
+</DocumentFragment>
+`;
+
+exports[`Image component Image snapshots renders default loading message if thing is undefined and there is no error 1`] = `
+<DocumentFragment>
+  <span>
+    fetching data in progress
+  </span>
+</DocumentFragment>
+`;
+
+exports[`Image component Image snapshots renders loading component if passed and thing is undefined and there is no error 1`] = `
+<DocumentFragment>
+  <span
+    id="custom-loading-component"
+  >
+    loading...
   </span>
 </DocumentFragment>
 `;

--- a/src/components/image/index.test.tsx
+++ b/src/components/image/index.test.tsx
@@ -134,6 +134,25 @@ describe("Image component", () => {
 
       expect(asFragment()).toMatchSnapshot();
     });
+    it("does not render default loading message if loadingComponent is null", () => {
+      jest.spyOn(helpers, "useProperty").mockReturnValueOnce({
+        thing: undefined,
+        error: undefined,
+        value: null,
+        setDataset: jest.fn(),
+        setThing: jest.fn(),
+        property: mockProperty,
+      });
+      const { asFragment } = render(
+        <Image
+          thing={undefined}
+          property="https://example.com/bad-url"
+          loadingComponent={null}
+        />
+      );
+
+      expect(asFragment()).toMatchSnapshot();
+    });
   });
 
   describe("Image functional tests", () => {

--- a/src/components/image/index.tsx
+++ b/src/components/image/index.tsx
@@ -34,7 +34,7 @@ export type Props = {
   maxSize?: number;
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
   errorComponent?: React.ComponentType<{ error: Error }>;
-  loadingComponent?: React.ComponentType;
+  loadingComponent?: React.ComponentType | null;
 } & CommonProperties &
   React.ImgHTMLAttributes<HTMLImageElement>;
 
@@ -55,7 +55,7 @@ export function Image({
   errorComponent: ErrorComponent,
   loadingComponent: LoadingComponent,
   ...imgOptions
-}: Props): ReactElement {
+}: Props): ReactElement | null {
   const { fetch } = useContext(SessionContext);
 
   const values = useProperty({
@@ -73,7 +73,7 @@ export function Image({
   const isFetchingThing = !thing && !thingError;
 
   const [error, setError] = useState<Error | undefined>(
-    thingError || valueError
+    thingError ?? valueError
   );
 
   useEffect(() => {
@@ -129,10 +129,13 @@ export function Image({
   let imageComponent = null;
 
   if (isFetchingThing) {
-    if (LoadingComponent) {
-      return <LoadingComponent />;
+    let loader: JSX.Element | null = (LoadingComponent && (
+      <LoadingComponent />
+    )) || <span>fetching data in progress</span>;
+    if (LoadingComponent === null) {
+      loader = null;
     }
-    return <span>fetching data in progress</span>;
+    return loader;
   }
 
   if (error) {

--- a/src/components/link/__snapshots__/index.test.tsx.snap
+++ b/src/components/link/__snapshots__/index.test.tsx.snap
@@ -11,7 +11,37 @@ exports[`Link component Link snapshot 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Link component When getUrl returns null, should throw an error 1`] = `"URL not found for given property"`;
+exports[`Link component matches snapshot while fetching data 1`] = `
+<body>
+  <div>
+    <span>
+      fetching data in progress
+    </span>
+  </div>
+</body>
+`;
+
+exports[`Link component renders custom error component if passed and there is an error 1`] = `
+<body>
+  <div>
+    <span
+      id="custom-error-component"
+    >
+      Error: URL not found for given property
+    </span>
+  </div>
+</body>
+`;
+
+exports[`Link component renders default error message if there is an error 1`] = `
+<body>
+  <div>
+    <span>
+      Error: URL not found for given property
+    </span>
+  </div>
+</body>
+`;
 
 exports[`Link component renders in edit mode 1`] = `
 <DocumentFragment>
@@ -22,4 +52,16 @@ exports[`Link component renders in edit mode 1`] = `
     http://test.url
   </a>
 </DocumentFragment>
+`;
+
+exports[`Link component renders loading component if passed while fetching data 1`] = `
+<body>
+  <div>
+    <span
+      id="custom-loading-component"
+    >
+      loading...
+    </span>
+  </div>
+</body>
 `;

--- a/src/components/link/__snapshots__/index.test.tsx.snap
+++ b/src/components/link/__snapshots__/index.test.tsx.snap
@@ -11,6 +11,12 @@ exports[`Link component Link snapshot 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Link component does not render default loading message if loadingComponent is null 1`] = `
+<body>
+  <div />
+</body>
+`;
+
 exports[`Link component matches snapshot while fetching data 1`] = `
 <body>
   <div>

--- a/src/components/link/index.test.tsx
+++ b/src/components/link/index.test.tsx
@@ -96,6 +96,21 @@ describe("Link component", () => {
     const { baseElement } = documentBody;
     expect(baseElement).toMatchSnapshot();
   });
+  it("does not render default loading message if loadingComponent is null", () => {
+    jest.spyOn(helpers, "useProperty").mockReturnValueOnce({
+      thing: undefined,
+      error: undefined,
+      value: null,
+      setDataset: jest.fn(),
+      setThing: jest.fn(),
+      property: mockPredicate,
+    });
+    const documentBody = render(
+      <Link property={mockPredicate} loadingComponent={null} />
+    );
+    const { baseElement } = documentBody;
+    expect(baseElement).toMatchSnapshot();
+  });
   it("Should call getUrl and use result as href value", () => {
     jest.spyOn(SolidFns, "getUrl").mockImplementationOnce(() => mockUrl);
     const { getByText } = render(

--- a/src/components/link/index.tsx
+++ b/src/components/link/index.tsx
@@ -25,7 +25,7 @@ import { CommonProperties, useProperty } from "../../helpers";
 import { Value } from "../value";
 
 export type Props = {
-  loadingComponent?: React.ComponentType;
+  loadingComponent?: React.ComponentType | null;
   errorComponent?: React.ComponentType<{ error: Error }>;
 } & CommonProperties &
   React.AnchorHTMLAttributes<HTMLAnchorElement>;
@@ -48,7 +48,7 @@ export function Link({
   onSave,
   onError,
   ...linkOptions
-}: Props): ReactElement {
+}: Props): ReactElement | null {
   const {
     value: href,
     thing,
@@ -70,13 +70,16 @@ export function Link({
 
   const isFetchingThing = !thing && !thingError;
 
-  const [error] = useState<Error | undefined>(thingError || valueError);
+  const [error] = useState<Error | undefined>(thingError ?? valueError);
 
   if (isFetchingThing) {
-    if (LoadingComponent) {
-      return <LoadingComponent />;
+    let loader: JSX.Element | null = (LoadingComponent && (
+      <LoadingComponent />
+    )) || <span>fetching data in progress</span>;
+    if (LoadingComponent === null) {
+      loader = null;
     }
-    return <span>fetching data in progress</span>;
+    return loader;
   }
 
   if (error) {

--- a/src/components/text/__snapshots__/index.test.tsx.snap
+++ b/src/components/text/__snapshots__/index.test.tsx.snap
@@ -10,6 +10,16 @@ exports[`<Text /> component snapshot test matches snapshot 1`] = `
 </body>
 `;
 
+exports[`<Text /> component snapshot test matches snapshot while fetching data 1`] = `
+<body>
+  <div>
+    <h3>
+      fetching data in progress
+    </h3>
+  </div>
+</body>
+`;
+
 exports[`<Text /> component snapshot test matches snapshot with data from context 1`] = `
 <body>
   <div>
@@ -29,6 +39,40 @@ exports[`<Text /> component snapshot test matches snapshot with edit true and in
       type="url"
       value="test nick value"
     />
+  </div>
+</body>
+`;
+
+exports[`<Text /> component snapshot test renders custom error component if passed and there is an error 1`] = `
+<body>
+  <div>
+    <span
+      id="custom-error-component"
+    >
+      Error: No value found for property.
+    </span>
+  </div>
+</body>
+`;
+
+exports[`<Text /> component snapshot test renders default error message if there is an error 1`] = `
+<body>
+  <div>
+    <span>
+      Error: No value found for property.
+    </span>
+  </div>
+</body>
+`;
+
+exports[`<Text /> component snapshot test renders loading component if passed while fetching data 1`] = `
+<body>
+  <div>
+    <span
+      id="custom-loading-component"
+    >
+      loading...
+    </span>
   </div>
 </body>
 `;

--- a/src/components/text/__snapshots__/index.test.tsx.snap
+++ b/src/components/text/__snapshots__/index.test.tsx.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Text /> component snapshot test does not render defualt loading message if loadingComponent is null 1`] = `
+<body>
+  <div />
+</body>
+`;
+
 exports[`<Text /> component snapshot test matches snapshot 1`] = `
 <body>
   <div>
@@ -13,9 +19,9 @@ exports[`<Text /> component snapshot test matches snapshot 1`] = `
 exports[`<Text /> component snapshot test matches snapshot while fetching data 1`] = `
 <body>
   <div>
-    <h3>
+    <span>
       fetching data in progress
-    </h3>
+    </span>
   </div>
 </body>
 `;

--- a/src/components/text/index.test.tsx
+++ b/src/components/text/index.test.tsx
@@ -130,6 +130,22 @@ describe("<Text /> component snapshot test", () => {
     expect(baseElement).toMatchSnapshot();
   });
 
+  it("does not render defualt loading message if loadingComponent is null", () => {
+    jest.spyOn(helpers, "useProperty").mockReturnValueOnce({
+      thing: undefined,
+      error: undefined,
+      value: null,
+      setDataset: jest.fn(),
+      setThing: jest.fn(),
+      property: mockPredicate,
+    });
+    const documentBody = render(
+      <Text property={mockPredicate} loadingComponent={null} />
+    );
+    const { baseElement } = documentBody;
+    expect(baseElement).toMatchSnapshot();
+  });
+
   it("renders default error message if there is an error", () => {
     const emptyThing = SolidFns.createThing();
     const documentBody = render(

--- a/src/components/text/index.test.tsx
+++ b/src/components/text/index.test.tsx
@@ -24,6 +24,7 @@ import * as React from "react";
 import { render, fireEvent, waitFor } from "@testing-library/react";
 import { ErrorBoundary } from "react-error-boundary";
 import * as SolidFns from "@inrupt/solid-client";
+import * as helpers from "../../helpers";
 import { Text } from "./index";
 import { DatasetProvider } from "../../context/datasetContext";
 import { ThingProvider } from "../../context/thingContext";
@@ -89,6 +90,64 @@ describe("<Text /> component snapshot test", () => {
         solidDataset={mockDatasetWithResourceInfo}
         thing={mockThing}
         property={mockPredicate}
+      />
+    );
+    const { baseElement } = documentBody;
+    expect(baseElement).toMatchSnapshot();
+  });
+  it("matches snapshot while fetching data", () => {
+    jest.spyOn(helpers, "useProperty").mockReturnValueOnce({
+      thing: undefined,
+      error: undefined,
+      value: null,
+      setDataset: jest.fn(),
+      setThing: jest.fn(),
+      property: mockPredicate,
+    });
+    const documentBody = render(<Text property={mockPredicate} />);
+    const { baseElement } = documentBody;
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it("renders loading component if passed while fetching data", () => {
+    jest.spyOn(helpers, "useProperty").mockReturnValueOnce({
+      thing: undefined,
+      error: undefined,
+      value: null,
+      setDataset: jest.fn(),
+      setThing: jest.fn(),
+      property: mockPredicate,
+    });
+    const documentBody = render(
+      <Text
+        property={mockPredicate}
+        loadingComponent={() => (
+          <span id="custom-loading-component">loading...</span>
+        )}
+      />
+    );
+    const { baseElement } = documentBody;
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it("renders default error message if there is an error", () => {
+    const emptyThing = SolidFns.createThing();
+    const documentBody = render(
+      <Text thing={emptyThing} property="https://example.com/bad-url" />
+    );
+    const { baseElement } = documentBody;
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it("renders custom error component if passed and there is an error", () => {
+    const emptyThing = SolidFns.createThing();
+    const documentBody = render(
+      <Text
+        thing={emptyThing}
+        property="https://example.com/bad-url"
+        errorComponent={({ error }) => (
+          <span id="custom-error-component">{error.toString()}</span>
+        )}
       />
     );
     const { baseElement } = documentBody;

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -38,7 +38,7 @@ export type Props = {
   saveDatasetTo?: Url | UrlString;
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
   locale?: string;
-  loadingComponent?: React.ComponentType;
+  loadingComponent?: React.ComponentType | null;
   errorComponent?: React.ComponentType<{ error: Error }>;
 } & CommonProperties;
 
@@ -60,7 +60,7 @@ export function Text({
   errorComponent: ErrorComponent,
   loadingComponent: LoadingComponent,
   ...other
-}: Props & React.HTMLAttributes<HTMLSpanElement>): ReactElement {
+}: Props & React.HTMLAttributes<HTMLSpanElement>): ReactElement | null {
   const { fetch } = useContext(SessionContext);
 
   const {
@@ -86,7 +86,7 @@ export function Text({
 
   const isFetchingThing = !thing && !thingError;
 
-  const [error] = useState<Error | undefined>(thingError || valueError);
+  const [error] = useState<Error | undefined>(thingError ?? valueError);
 
   useEffect(() => {
     if (error && onError) {
@@ -154,10 +154,13 @@ export function Text({
   };
 
   if (isFetchingThing) {
-    if (LoadingComponent) {
-      return <LoadingComponent />;
+    let loader: JSX.Element | null = (LoadingComponent && (
+      <LoadingComponent />
+    )) || <span>fetching data in progress</span>;
+    if (LoadingComponent === null) {
+      loader = null;
     }
-    return <h3>fetching data in progress</h3>;
+    return loader;
   }
 
   if (error) {

--- a/src/components/value/__snapshots__/index.test.tsx.snap
+++ b/src/components/value/__snapshots__/index.test.tsx.snap
@@ -121,3 +121,57 @@ exports[`<Value /> component snapshot test matches snapshot with edit true and i
   </div>
 </body>
 `;
+
+exports[`<Value /> component snapshot test renders 'false' if dataType is boolean instead of error if property not found 1`] = `
+<body>
+  <div>
+    <span>
+      false
+    </span>
+  </div>
+</body>
+`;
+
+exports[`<Value /> component snapshot test renders custom error component if passed and there is an error 1`] = `
+<body>
+  <div>
+    <span
+      id="custom-error-component"
+    >
+      Error: No value found for property.
+    </span>
+  </div>
+</body>
+`;
+
+exports[`<Value /> component snapshot test renders default error message if there is an error 1`] = `
+<body>
+  <div>
+    <span>
+      Error: No value found for property.
+    </span>
+  </div>
+</body>
+`;
+
+exports[`<Value /> component snapshot test renders error if dataType is boolean and there is an error fetching the thing 1`] = `
+<body>
+  <div>
+    <span>
+      Error: Thing not found as property or in context
+    </span>
+  </div>
+</body>
+`;
+
+exports[`<Value /> component snapshot test renders loading component if passed while fetching data 1`] = `
+<body>
+  <div>
+    <span
+      id="custom-loading-component"
+    >
+      loading...
+    </span>
+  </div>
+</body>
+`;

--- a/src/components/value/__snapshots__/index.test.tsx.snap
+++ b/src/components/value/__snapshots__/index.test.tsx.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Value /> component snapshot test does not render default loading message if loadingComponent is null 1`] = `
+<body>
+  <div />
+</body>
+`;
+
 exports[`<Value /> component snapshot test matches snapshot 1`] = `
 <body>
   <div>

--- a/src/components/value/index.test.tsx
+++ b/src/components/value/index.test.tsx
@@ -86,8 +86,96 @@ describe("<Value /> component snapshot test", () => {
   });
 
   it("matches snapshot while fetching data", () => {
+    jest.spyOn(helpers, "useProperty").mockReturnValueOnce({
+      thing: undefined,
+      error: undefined,
+      value: null,
+      setDataset: jest.fn(),
+      setThing: jest.fn(),
+      property: mockPredicate,
+    });
     const documentBody = render(
       <Value dataType="string" property={mockPredicate} />
+    );
+    const { baseElement } = documentBody;
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it("renders loading component if passed while fetching data", () => {
+    jest.spyOn(helpers, "useProperty").mockReturnValueOnce({
+      thing: undefined,
+      error: undefined,
+      value: null,
+      setDataset: jest.fn(),
+      setThing: jest.fn(),
+      property: mockPredicate,
+    });
+    const documentBody = render(
+      <Value
+        dataType="string"
+        property={mockPredicate}
+        loadingComponent={() => (
+          <span id="custom-loading-component">loading...</span>
+        )}
+      />
+    );
+    const { baseElement } = documentBody;
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it("renders default error message if there is an error", () => {
+    const emptyThing = SolidFns.createThing();
+    const documentBody = render(
+      <Value
+        thing={emptyThing}
+        dataType="string"
+        property="https://example.com/bad-url"
+      />
+    );
+    const { baseElement } = documentBody;
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it("renders custom error component if passed and there is an error", () => {
+    const emptyThing = SolidFns.createThing();
+    const documentBody = render(
+      <Value
+        thing={emptyThing}
+        dataType="string"
+        property="https://example.com/bad-url"
+        errorComponent={({ error }) => (
+          <span id="custom-error-component">{error.toString()}</span>
+        )}
+      />
+    );
+    const { baseElement } = documentBody;
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it("renders 'false' if dataType is boolean instead of error if property not found", () => {
+    const emptyThing = SolidFns.createThing();
+    const documentBody = render(
+      <DatasetProvider solidDataset={mockDatasetWithResourceInfo}>
+        <ThingProvider thing={mockThing}>
+          <Value
+            thing={emptyThing}
+            dataType="boolean"
+            property="http://xmlns.com/foaf/0.1/name"
+          />
+        </ThingProvider>
+      </DatasetProvider>
+    );
+    const { baseElement } = documentBody;
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it("renders error if dataType is boolean and there is an error fetching the thing", () => {
+    const documentBody = render(
+      <Value
+        thing={undefined}
+        dataType="boolean"
+        property="http://xmlns.com/foaf/0.1/name"
+      />
     );
     const { baseElement } = documentBody;
     expect(baseElement).toMatchSnapshot();

--- a/src/components/value/index.test.tsx
+++ b/src/components/value/index.test.tsx
@@ -123,6 +123,26 @@ describe("<Value /> component snapshot test", () => {
     expect(baseElement).toMatchSnapshot();
   });
 
+  it("does not render default loading message if loadingComponent is null", () => {
+    jest.spyOn(helpers, "useProperty").mockReturnValueOnce({
+      thing: undefined,
+      error: undefined,
+      value: null,
+      setDataset: jest.fn(),
+      setThing: jest.fn(),
+      property: mockPredicate,
+    });
+    const documentBody = render(
+      <Value
+        dataType="string"
+        property={mockPredicate}
+        loadingComponent={null}
+      />
+    );
+    const { baseElement } = documentBody;
+    expect(baseElement).toMatchSnapshot();
+  });
+
   it("renders default error message if there is an error", () => {
     const emptyThing = SolidFns.createThing();
     const documentBody = render(

--- a/src/components/value/index.tsx
+++ b/src/components/value/index.tsx
@@ -35,14 +35,14 @@ export type Props = {
   saveDatasetTo?: Url | UrlString;
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
   locale?: string;
-  loadingComponent?: React.ComponentType;
+  loadingComponent?: React.ComponentType | null;
   errorComponent?: React.ComponentType<{ error: Error }>;
 } & CommonProperties;
 
 /**
  * Retrieves and displays a value of one of a range of types from a given [Dataset](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/glossary/#term-SolidDataset)/[Thing](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/glossary/#term-Thing)/property. Can also be used to set/update and persist a value.
  */
-export function Value(props: Props): ReactElement {
+export function Value(props: Props): ReactElement | null {
   const { dataType, ...otherProps } = props as Props;
   const {
     thing: propThing,
@@ -70,13 +70,16 @@ export function Value(props: Props): ReactElement {
 
   const isFetchingThing = !thing && !thingError;
 
-  const [error] = useState<Error | undefined>(thingError || valueError);
+  const [error] = useState<Error | undefined>(thingError ?? valueError);
 
   if (isFetchingThing) {
-    if (LoadingComponent) {
-      return <LoadingComponent />;
+    let loader: JSX.Element | null = (LoadingComponent && (
+      <LoadingComponent />
+    )) || <span>fetching data in progress</span>;
+    if (LoadingComponent === null) {
+      loader = null;
     }
-    return <span>fetching data in progress</span>;
+    return loader;
   }
 
   if (error) {

--- a/src/components/video/__snapshots__/index.test.tsx.snap
+++ b/src/components/video/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Video component Video functional tests When getUrl returns null, with an errorComponent, should render the error 1`] = `
 <DocumentFragment>
   <span>
-    Error: URL not found for given property
+    Error: No value found for property.
   </span>
 </DocumentFragment>
 `;
@@ -36,8 +36,36 @@ exports[`Video component Video snapshots matches snapshot with standard props 1`
 
 exports[`Video component Video snapshots renders an error message if an errorComponent is provided 1`] = `
 <DocumentFragment>
+  <span
+    id="custom-error-component"
+  >
+    Error: No value found for property.
+  </span>
+</DocumentFragment>
+`;
+
+exports[`Video component Video snapshots renders default error message if there is an error and no errorComponent is passed 1`] = `
+<DocumentFragment>
   <span>
-    Error: URL not found for given property
+    Error: No value found for property.
+  </span>
+</DocumentFragment>
+`;
+
+exports[`Video component Video snapshots renders default loading message if thing is undefined and there is no error 1`] = `
+<DocumentFragment>
+  <span>
+    fetching data in progress
+  </span>
+</DocumentFragment>
+`;
+
+exports[`Video component Video snapshots renders loading component if passed and thing is undefined and there is no error 1`] = `
+<DocumentFragment>
+  <span
+    id="custom-loading-component"
+  >
+    loading...
   </span>
 </DocumentFragment>
 `;

--- a/src/components/video/__snapshots__/index.test.tsx.snap
+++ b/src/components/video/__snapshots__/index.test.tsx.snap
@@ -8,6 +8,8 @@ exports[`Video component Video functional tests When getUrl returns null, with a
 </DocumentFragment>
 `;
 
+exports[`Video component Video snapshots does not render default loading message if loadingComponent is null 1`] = `<DocumentFragment />`;
+
 exports[`Video component Video snapshots matches snapshot with additional props for video and input 1`] = `
 <DocumentFragment>
   <video

--- a/src/components/video/index.test.tsx
+++ b/src/components/video/index.test.tsx
@@ -135,6 +135,26 @@ describe("Video component", () => {
 
       expect(asFragment()).toMatchSnapshot();
     });
+
+    it("does not render default loading message if loadingComponent is null", () => {
+      jest.spyOn(helpers, "useProperty").mockReturnValueOnce({
+        thing: undefined,
+        error: undefined,
+        value: null,
+        setDataset: jest.fn(),
+        setThing: jest.fn(),
+        property: mockProperty,
+      });
+      const { asFragment } = render(
+        <Video
+          thing={undefined}
+          property="https://example.com/bad-url"
+          loadingComponent={null}
+        />
+      );
+
+      expect(asFragment()).toMatchSnapshot();
+    });
   });
   describe("Video functional tests", () => {
     beforeEach(() => {

--- a/src/components/video/index.test.tsx
+++ b/src/components/video/index.test.tsx
@@ -21,9 +21,9 @@
 
 import React from "react";
 import { render, waitFor, fireEvent } from "@testing-library/react";
-import { ErrorBoundary } from "react-error-boundary";
 import * as SolidFns from "@inrupt/solid-client";
 import { Video } from ".";
+import * as helpers from "../../helpers";
 
 const mockTitle = "test video";
 const mockUrl = "http://test.url/video.mp4";
@@ -39,16 +39,12 @@ const mockFile = SolidFns.mockFileFrom(mockUrl);
 
 window.URL.createObjectURL = jest.fn(() => mockObjectUrl);
 
-jest.spyOn(SolidFns, "getUrl").mockImplementation(() => mockUrl);
-jest.spyOn(SolidFns, "getFile").mockResolvedValue(mockFile);
-jest.spyOn(SolidFns, "overwriteFile").mockResolvedValue(mockFile);
-
 describe("Video component", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
   describe("Video snapshots", () => {
     it("matches snapshot with standard props", async () => {
+      jest.spyOn(SolidFns, "getUrl").mockImplementationOnce(() => mockUrl);
+      jest.spyOn(SolidFns, "getFile").mockResolvedValueOnce(mockFile);
+      jest.spyOn(SolidFns, "overwriteFile").mockResolvedValueOnce(mockFile);
       const { asFragment, getByTitle } = render(
         <Video thing={mockThing} property={mockProperty} title={mockTitle} />
       );
@@ -59,6 +55,9 @@ describe("Video component", () => {
     });
 
     it("matches snapshot with additional props for video and input", async () => {
+      jest.spyOn(SolidFns, "getUrl").mockImplementationOnce(() => mockUrl);
+      jest.spyOn(SolidFns, "getFile").mockResolvedValueOnce(mockFile);
+      jest.spyOn(SolidFns, "overwriteFile").mockResolvedValueOnce(mockFile);
       const { asFragment, getByTitle } = render(
         <Video
           thing={mockThing}
@@ -76,11 +75,61 @@ describe("Video component", () => {
     });
 
     it("renders an error message if an errorComponent is provided", () => {
+      const emptyThing = SolidFns.createThing();
+      const { asFragment } = render(
+        <Video
+          thing={emptyThing}
+          property="https://example.com/bad-url"
+          errorComponent={({ error }) => (
+            <span id="custom-error-component">{error.toString()}</span>
+          )}
+        />
+      );
+      expect(asFragment()).toMatchSnapshot();
+    });
+
+    it("renders default error message if there is an error and no errorComponent is passed", () => {
+      const emptyThing = SolidFns.createThing();
+
+      const { asFragment } = render(
+        <Video thing={emptyThing} property="https://example.com/bad-url" />
+      );
+
+      expect(asFragment()).toMatchSnapshot();
+    });
+
+    it("renders default loading message if thing is undefined and there is no error", () => {
+      jest.spyOn(helpers, "useProperty").mockReturnValueOnce({
+        thing: undefined,
+        error: undefined,
+        value: null,
+        setDataset: jest.fn(),
+        setThing: jest.fn(),
+        property: mockProperty,
+      });
+      const { asFragment } = render(
+        <Video thing={undefined} property="https://example.com/bad-url" />
+      );
+
+      expect(asFragment()).toMatchSnapshot();
+    });
+
+    it("renders loading component if passed and thing is undefined and there is no error", () => {
+      jest.spyOn(helpers, "useProperty").mockReturnValueOnce({
+        thing: undefined,
+        error: undefined,
+        value: null,
+        setDataset: jest.fn(),
+        setThing: jest.fn(),
+        property: mockProperty,
+      });
       const { asFragment } = render(
         <Video
           thing={undefined}
           property="https://example.com/bad-url"
-          errorComponent={({ error }) => <span>{error.toString()}</span>}
+          loadingComponent={() => (
+            <span id="custom-loading-component">loading...</span>
+          )}
         />
       );
 
@@ -88,6 +137,12 @@ describe("Video component", () => {
     });
   });
   describe("Video functional tests", () => {
+    beforeEach(() => {
+      jest.spyOn(SolidFns, "getUrl").mockImplementation(() => mockUrl);
+      jest.spyOn(SolidFns, "getFile").mockResolvedValue(mockFile);
+      jest.spyOn(SolidFns, "overwriteFile").mockResolvedValue(mockFile);
+    });
+
     it("Should call getUrl using given thing and property", async () => {
       const { getByTitle } = render(
         <Video thing={mockThing} property={mockProperty} title={mockTitle} />

--- a/src/components/video/index.tsx
+++ b/src/components/video/index.tsx
@@ -34,7 +34,7 @@ export type Props = {
   maxSize?: number;
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
   errorComponent?: React.ComponentType<{ error: Error }>;
-  loadingComponent?: React.ComponentType;
+  loadingComponent?: React.ComponentType | null;
 } & CommonProperties &
   React.VideoHTMLAttributes<HTMLVideoElement>;
 
@@ -54,7 +54,7 @@ export function Video({
   errorComponent: ErrorComponent,
   loadingComponent: LoadingComponent,
   ...videoOptions
-}: Props): ReactElement {
+}: Props): ReactElement | null {
   const { fetch } = useContext(SessionContext);
 
   const values = useProperty({
@@ -73,7 +73,7 @@ export function Video({
   const isFetchingThing = !thing && !thingError;
 
   const [error, setError] = useState<Error | undefined>(
-    thingError || valueError
+    thingError ?? valueError
   );
 
   useEffect(() => {
@@ -128,10 +128,13 @@ export function Video({
   let videoComponent = null;
 
   if (isFetchingThing) {
-    if (LoadingComponent) {
-      return <LoadingComponent />;
+    let loader: JSX.Element | null = (LoadingComponent && (
+      <LoadingComponent />
+    )) || <span>fetching data in progress</span>;
+    if (LoadingComponent === null) {
+      loader = null;
     }
-    return <span>fetching data in progress</span>;
+    return loader;
   }
 
   if (error) {

--- a/src/context/combinedDataContext/index.tsx
+++ b/src/context/combinedDataContext/index.tsx
@@ -33,6 +33,7 @@ import { ThingProvider } from "../thingContext";
 
 export type Props = {
   children: React.ReactNode;
+  loadingComponent?: React.ReactNode;
   onError?(error: Error): void | null;
 };
 
@@ -77,6 +78,7 @@ function CombinedDataProvider(props: any): ReactElement {
     thing,
     thingUrl,
     onError,
+    loadingComponent,
   } = props;
 
   return (
@@ -84,6 +86,7 @@ function CombinedDataProvider(props: any): ReactElement {
       onError={onError}
       solidDataset={solidDataset}
       datasetUrl={datasetUrl}
+      loadingComponent={loadingComponent}
     >
       <ThingProvider thing={thing} thingUrl={thingUrl}>
         {children}

--- a/src/context/combinedDataContext/index.tsx
+++ b/src/context/combinedDataContext/index.tsx
@@ -33,7 +33,7 @@ import { ThingProvider } from "../thingContext";
 
 export type Props = {
   children: React.ReactNode;
-  loadingComponent?: React.ReactNode;
+  loadingComponent?: React.ComponentType | null;
   onError?(error: Error): void | null;
 };
 

--- a/src/context/datasetContext/__snapshots__/index.test.tsx.snap
+++ b/src/context/datasetContext/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,31 @@
 
 exports[`Testing DatasetContext matches snapshot when fetching 1`] = `
 <body>
-  <div />
+  <div>
+    <span>
+      Fetching data...
+    </span>
+  </div>
+</body>
+`;
+
+exports[`Testing DatasetContext matches snapshot when fetching and loading is passed 1`] = `
+<body>
+  <div>
+    <span>
+      loading
+    </span>
+  </div>
+</body>
+`;
+
+exports[`Testing DatasetContext matches snapshot when fetching and loadingComponent is passed 1`] = `
+<body>
+  <div>
+    <span>
+      loading component
+    </span>
+  </div>
 </body>
 `;
 
@@ -13,6 +37,12 @@ exports[`Testing DatasetContext matches snapshot when fetching fails 1`] = `
       Fetching data...
     </span>
   </div>
+</body>
+`;
+
+exports[`Testing DatasetContext matches snapshot when loadingComponent is null 1`] = `
+<body>
+  <div />
 </body>
 `;
 

--- a/src/context/datasetContext/index.test.tsx
+++ b/src/context/datasetContext/index.test.tsx
@@ -155,9 +155,59 @@ describe("Testing DatasetContext", () => {
       error: undefined,
     });
     documentBody = render(
+      <DatasetProvider datasetUrl="https://some-broken-resource.com">
+        <ExampleComponentWithDataset />
+      </DatasetProvider>
+    );
+
+    const { baseElement } = documentBody;
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it("matches snapshot when fetching and loadingComponent is passed", async () => {
+    (useDataset as jest.Mock).mockReturnValue({
+      solidDataset: undefined,
+      error: undefined,
+    });
+    documentBody = render(
       <DatasetProvider
         datasetUrl="https://some-broken-resource.com"
-        loadingComponent={() => "loading"}
+        loadingComponent={() => <span>loading component</span>}
+      >
+        <ExampleComponentWithDataset />
+      </DatasetProvider>
+    );
+
+    const { baseElement } = documentBody;
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it("matches snapshot when fetching and loading is passed", async () => {
+    (useDataset as jest.Mock).mockReturnValue({
+      solidDataset: undefined,
+      error: undefined,
+    });
+    documentBody = render(
+      <DatasetProvider
+        datasetUrl="https://some-broken-resource.com"
+        loading={() => <span>loading</span>}
+      >
+        <ExampleComponentWithDataset />
+      </DatasetProvider>
+    );
+
+    const { baseElement } = documentBody;
+    expect(baseElement).toMatchSnapshot();
+  });
+  it("matches snapshot when loadingComponent is null", async () => {
+    (useDataset as jest.Mock).mockReturnValue({
+      solidDataset: undefined,
+      error: undefined,
+    });
+    documentBody = render(
+      <DatasetProvider
+        datasetUrl="https://some-broken-resource.com"
+        loadingComponent={null}
       >
         <ExampleComponentWithDataset />
       </DatasetProvider>

--- a/src/context/datasetContext/index.test.tsx
+++ b/src/context/datasetContext/index.test.tsx
@@ -157,7 +157,7 @@ describe("Testing DatasetContext", () => {
     documentBody = render(
       <DatasetProvider
         datasetUrl="https://some-broken-resource.com"
-        loading={() => "loading"}
+        loadingComponent={() => "loading"}
       >
         <ExampleComponentWithDataset />
       </DatasetProvider>

--- a/src/context/datasetContext/index.tsx
+++ b/src/context/datasetContext/index.tsx
@@ -42,7 +42,11 @@ export default DatasetContext;
 
 export interface IDatasetProvider {
   children: React.ReactNode;
-  loadingComponent?: React.ReactNode;
+  /**
+   * @deprecated `loading` is deprecated. It can still be used but may be removed in a future major release.`loadingComponent` should be used instead.
+   */
+  loading?: React.ComponentType;
+  loadingComponent?: React.ComponentType | null;
   onError?(error: Error): void | null;
   solidDataset?: SolidDataset | (SolidDataset & WithResourceInfo);
   datasetUrl?: UrlString | string;
@@ -63,7 +67,8 @@ export const DatasetProvider = ({
   onError,
   solidDataset: propDataset,
   datasetUrl,
-  loadingComponent,
+  loading: Loading,
+  loadingComponent: LoadingComponent,
 }: RequireDatasetOrDatasetUrl): ReactElement => {
   const { dataset, error } = useDataset(datasetUrl);
 
@@ -83,11 +88,16 @@ export const DatasetProvider = ({
     setDataset(datasetToUse);
   }, [datasetToUse]);
 
+  let loader: JSX.Element | null = (LoadingComponent && <LoadingComponent />) ||
+    (Loading && <Loading />) || <span>Fetching data...</span>;
+
+  if (LoadingComponent === null) {
+    loader = null;
+  }
+
   return (
     <DatasetContext.Provider value={{ solidDataset: stateDataset, setDataset }}>
-      {stateDataset
-        ? children
-        : loadingComponent || <span>Fetching data...</span>}
+      {stateDataset ? children : loader}
     </DatasetContext.Provider>
   );
 };

--- a/src/context/datasetContext/index.tsx
+++ b/src/context/datasetContext/index.tsx
@@ -42,7 +42,7 @@ export default DatasetContext;
 
 export interface IDatasetProvider {
   children: React.ReactNode;
-  loading?: React.ReactNode;
+  loadingComponent?: React.ReactNode;
   onError?(error: Error): void | null;
   solidDataset?: SolidDataset | (SolidDataset & WithResourceInfo);
   datasetUrl?: UrlString | string;
@@ -63,7 +63,7 @@ export const DatasetProvider = ({
   onError,
   solidDataset: propDataset,
   datasetUrl,
-  loading,
+  loadingComponent,
 }: RequireDatasetOrDatasetUrl): ReactElement => {
   const { dataset, error } = useDataset(datasetUrl);
 
@@ -85,7 +85,9 @@ export const DatasetProvider = ({
 
   return (
     <DatasetContext.Provider value={{ solidDataset: stateDataset, setDataset }}>
-      {stateDataset ? children : loading || <span>Fetching data...</span>}
+      {stateDataset
+        ? children
+        : loadingComponent || <span>Fetching data...</span>}
     </DatasetContext.Provider>
   );
 };

--- a/stories/components/image.stories.tsx
+++ b/stories/components/image.stories.tsx
@@ -72,7 +72,7 @@ export default {
       control: { type: null },
     },
     loadingComponent: {
-      description: `Component to be rendered while fetching data.`,
+      description: `A loading component to show while fetching the dataset. If \`null\` the default loading message won't be displayed`,
       control: { type: null },
     },
   },

--- a/stories/components/image.stories.tsx
+++ b/stories/components/image.stories.tsx
@@ -71,6 +71,10 @@ export default {
       description: `Component to be rendered in case of error.`,
       control: { type: null },
     },
+    loadingComponent: {
+      description: `Component to be rendered while fetching data.`,
+      control: { type: null },
+    },
   },
 };
 

--- a/stories/components/link.stories.tsx
+++ b/stories/components/link.stories.tsx
@@ -39,7 +39,7 @@ export default {
       control: { type: null },
     },
     loadingComponent: {
-      description: `Component to be rendered while fetching data.`,
+      description: `A loading component to show while fetching the dataset. If \`null\` the default loading message won't be displayed`,
       control: { type: null },
     },
   },

--- a/stories/components/link.stories.tsx
+++ b/stories/components/link.stories.tsx
@@ -34,6 +34,14 @@ export default {
     thing: {
       description: `The [Thing](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/glossary/#term-Thing) to retrieve the link URL from.`,
     },
+    errorComponent: {
+      description: `Component to be rendered in case of error.`,
+      control: { type: null },
+    },
+    loadingComponent: {
+      description: `Component to be rendered while fetching data.`,
+      control: { type: null },
+    },
   },
 };
 
@@ -110,4 +118,26 @@ Editable.parameters = {
 
 Editable.args = {
   property: "http://xmlns.com/foaf/0.1/homepage",
+};
+
+export function ErrorComponent(): ReactElement {
+  const exampleUrl = "http://test.url";
+  const property = "http://xmlns.com/foaf/0.1/homepage";
+  const exampleThing = SolidFns.addUrl(
+    SolidFns.createThing(),
+    property,
+    exampleUrl
+  );
+  return (
+    <Link
+      thing={exampleThing}
+      property="https://example.com/bad-url"
+      errorComponent={({ error }) => <span>{error.toString()}</span>}
+    />
+  );
+}
+
+ErrorComponent.parameters = {
+  actions: { disable: true },
+  controls: { disable: true },
 };

--- a/stories/components/text.stories.tsx
+++ b/stories/components/text.stories.tsx
@@ -65,6 +65,14 @@ export default {
     inputProps: {
       description: `Additional attributes to be passed to the file input, if \`edit\` is true`,
     },
+    errorComponent: {
+      description: `Component to be rendered in case of error.`,
+      control: { type: null },
+    },
+    loadingComponent: {
+      description: `Component to be rendered while fetching data.`,
+      control: { type: null },
+    },
   },
 };
 
@@ -206,4 +214,27 @@ WithFetchedData.args = {
   property: "http://xmlns.com/foaf/0.1/name",
   datasetUrl: `${host}/example.ttl`,
   thingUrl: `${host}/example.ttl#me`,
+};
+
+export function ErrorComponent(): ReactElement {
+  const exampleName = "Example Name";
+  const exampleProperty = "http://xmlns.com/foaf/0.1/name";
+  const exampleThing = SolidFns.addStringNoLocale(
+    SolidFns.createThing(),
+    exampleProperty,
+    exampleName
+  );
+
+  return (
+    <Text
+      thing={exampleThing}
+      property="https://example.com/bad-url"
+      errorComponent={({ error }) => <span>{error.toString()}</span>}
+    />
+  );
+}
+
+ErrorComponent.parameters = {
+  actions: { disable: true },
+  controls: { disable: true },
 };

--- a/stories/components/text.stories.tsx
+++ b/stories/components/text.stories.tsx
@@ -70,7 +70,7 @@ export default {
       control: { type: null },
     },
     loadingComponent: {
-      description: `Component to be rendered while fetching data.`,
+      description: `A loading component to show while fetching the dataset. If \`null\` the default loading message won't be displayed`,
       control: { type: null },
     },
   },

--- a/stories/components/value.stories.tsx
+++ b/stories/components/value.stories.tsx
@@ -101,7 +101,7 @@ export default {
       control: { type: null },
     },
     loadingComponent: {
-      description: `Component to be rendered while fetching data.`,
+      description: `A loading component to show while fetching the dataset. If \`null\` the default loading message won't be displayed`,
       control: { type: null },
     },
   },

--- a/stories/components/value.stories.tsx
+++ b/stories/components/value.stories.tsx
@@ -96,6 +96,14 @@ export default {
     thingUrl: {
       description: `**Not passed to Value**. Used to customise values of the wrapping [ThingProvider](/?path=/docs/providers-thing-provider) in the storybook examples`,
     },
+    errorComponent: {
+      description: `Component to be rendered in case of error.`,
+      control: { type: null },
+    },
+    loadingComponent: {
+      description: `Component to be rendered while fetching data.`,
+      control: { type: null },
+    },
   },
 };
 
@@ -414,4 +422,28 @@ export function WithFetchedData(
 
 WithFetchedData.args = {
   ...defaultArgs,
+};
+
+export function ErrorComponent(): ReactElement {
+  const exampleName = "Example Name";
+  const exampleProperty = "http://xmlns.com/foaf/0.1/name";
+  const exampleThing = SolidFns.addStringNoLocale(
+    SolidFns.createThing(),
+    exampleProperty,
+    exampleName
+  );
+
+  return (
+    <Value
+      dataType="string"
+      thing={exampleThing}
+      property="https://example.com/bad-url"
+      errorComponent={({ error }) => <span>{error.toString()}</span>}
+    />
+  );
+}
+
+ErrorComponent.parameters = {
+  actions: { disable: true },
+  controls: { disable: true },
 };

--- a/stories/components/video.stories.tsx
+++ b/stories/components/video.stories.tsx
@@ -64,6 +64,10 @@ export default {
       description: `Component to be rendered in case of error.`,
       control: { type: null },
     },
+    loadingComponent: {
+      description: `Component to be rendered while fetching data.`,
+      control: { type: null },
+    },
   },
 };
 

--- a/stories/components/video.stories.tsx
+++ b/stories/components/video.stories.tsx
@@ -65,7 +65,7 @@ export default {
       control: { type: null },
     },
     loadingComponent: {
-      description: `Component to be rendered while fetching data.`,
+      description: `A loading component to show while fetching the dataset. If \`null\` the default loading message won't be displayed`,
       control: { type: null },
     },
   },

--- a/stories/providers/combinedProvider.stories.tsx
+++ b/stories/providers/combinedProvider.stories.tsx
@@ -54,6 +54,10 @@ export default {
       description: `A url to retrieve the [Thing](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/glossary/#term-Thing) from, if \`Thing\` is not provided. Uses the Dataset from context.`,
       control: { type: null },
     },
+    loadingComponent: {
+      description: `A loading component to show while fetching the dataset.`,
+      control: { type: null },
+    },
     onError: {
       description: `Function to be called on error.`,
       action: "onError",

--- a/stories/providers/datasetProvider.stories.tsx
+++ b/stories/providers/datasetProvider.stories.tsx
@@ -41,7 +41,12 @@ export default {
       control: { type: null },
     },
     loadingComponent: {
-      description: `A loading component to show while fetching the dataset.`,
+      description: `A loading component to show while fetching the dataset. If \`null\` the default loading message won't be displayed`,
+      control: { type: null },
+    },
+    loading: {
+      description: `**Deprecated:** Use \`loadingComponent\`. 
+      \nA loading component to show while fetching the dataset`,
       control: { type: null },
     },
     onError: {

--- a/stories/providers/datasetProvider.stories.tsx
+++ b/stories/providers/datasetProvider.stories.tsx
@@ -40,7 +40,7 @@ export default {
       description: `A url to fetch the [Dataset](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/glossary/#term-SolidDataset) from, if \`Dataset\` is not provided.`,
       control: { type: null },
     },
-    loading: {
+    loadingComponent: {
       description: `A loading component to show while fetching the dataset.`,
       control: { type: null },
     },


### PR DESCRIPTION
This PR fixes #SDK-1401 and https://github.com/inrupt/solid-ui-react/issues/294.

# Standardize loading and error messages across components

In this PR:
- allowing an optional `loadingComponent` to be passed to the following components:
  - `Value`
  - `Text`
  - `Link`
  - `Image`
  - `Video`
- allowing an optional `errorComponent` to be passed to the following components:
  - `Value`
  - `Text`
  - `Link`
- In both cases a default message is displayed if the component is not passed. 
- When fetching thing fails, we now render an error instead of loading message, and only render the loading message when the Thing is being fetched.
- `loading` changed to `loadingComponent` in `DatasetProvider` to match the rest of the components
- `CombinedProvider` now receives this prop and passes it down to the `DatasetProvider`

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [ ] New functions/types have been exported in `index.ts`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
