### PR TITLE
Fetch dataset before updating context

### DIFF
--- a/src/components/text/__snapshots__/index.test.tsx.snap
+++ b/src/components/text/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Text /> component snapshot test does not render defualt loading message if loadingComponent is null 1`] = `
+exports[`<Text /> component snapshot test does not render default loading message if loadingComponent is null 1`] = `
 <body>
   <div />
 </body>

--- a/src/components/text/index.test.tsx
+++ b/src/components/text/index.test.tsx
@@ -53,6 +53,8 @@ const inputOptions = {
 };
 
 const savedDataset = SolidFns.createSolidDataset() as any;
+const latestDataset = SolidFns.createSolidDataset() as any;
+
 jest
   .spyOn(SolidFns, "saveSolidDatasetAt")
   .mockImplementation(() => savedDataset);
@@ -287,6 +289,7 @@ describe("<Text /> component functional testing", () => {
     const onSave = jest.fn();
     const onError = jest.fn();
     jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataset);
+    jest.spyOn(SolidFns, "getSolidDataset").mockResolvedValue(latestDataset);
     const { getByDisplayValue } = render(
       <Text
         solidDataset={mockDatasetWithResourceInfo}
@@ -309,6 +312,7 @@ describe("<Text /> component functional testing", () => {
     const onSave = jest.fn();
     const onError = jest.fn();
     jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataset);
+    jest.spyOn(SolidFns, "getSolidDataset").mockResolvedValue(latestDataset);
     const { getByDisplayValue } = render(
       <Text
         solidDataset={mockDatasetWithResourceInfo}
@@ -394,8 +398,9 @@ describe("<Text /> component functional testing", () => {
     // eslint-disable-next-line no-console
     (console.error as jest.Mock).mockRestore();
   });
-  it("Should update the dataset in context after saving", async () => {
+  it("Should update context with latest dataset after saving", async () => {
     jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataset);
+    jest.spyOn(SolidFns, "getSolidDataset").mockResolvedValue(latestDataset);
     const setDataset = jest.fn();
     const setThing = jest.fn();
     jest.spyOn(helpers, "useProperty").mockReturnValue({
@@ -422,6 +427,6 @@ describe("<Text /> component functional testing", () => {
     fireEvent.change(input, { target: { value: "updated nick value" } });
     input.blur();
     expect(SolidFns.saveSolidDatasetAt).toHaveBeenCalled();
-    await waitFor(() => expect(setDataset).toHaveBeenCalledWith(savedDataset));
+    await waitFor(() => expect(setDataset).toHaveBeenCalledWith(latestDataset));
   });
 });

--- a/src/components/text/index.test.tsx
+++ b/src/components/text/index.test.tsx
@@ -130,7 +130,7 @@ describe("<Text /> component snapshot test", () => {
     expect(baseElement).toMatchSnapshot();
   });
 
-  it("does not render defualt loading message if loadingComponent is null", () => {
+  it("does not render default loading message if loadingComponent is null", () => {
     jest.spyOn(helpers, "useProperty").mockReturnValueOnce({
       thing: undefined,
       error: undefined,
@@ -393,5 +393,35 @@ describe("<Text /> component functional testing", () => {
     await waitFor(() => expect(getByText("{}")).toBeDefined());
     // eslint-disable-next-line no-console
     (console.error as jest.Mock).mockRestore();
+  });
+  it("Should update the dataset in context after saving", async () => {
+    jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataset);
+    const setDataset = jest.fn();
+    const setThing = jest.fn();
+    jest.spyOn(helpers, "useProperty").mockReturnValue({
+      dataset: mockDataset,
+      setDataset,
+      setThing,
+      error: undefined,
+      value: mockNick,
+      thing: mockThing,
+      property: mockPredicate,
+    });
+    const { getByDisplayValue } = render(
+      <Text
+        solidDataset={mockDatasetWithResourceInfo}
+        thing={mockThing}
+        property={mockPredicate}
+        locale="en"
+        edit
+        autosave
+      />
+    );
+    const input = getByDisplayValue(mockNick);
+    input.focus();
+    fireEvent.change(input, { target: { value: "updated nick value" } });
+    input.blur();
+    expect(SolidFns.saveSolidDatasetAt).toHaveBeenCalled();
+    await waitFor(() => expect(setDataset).toHaveBeenCalledWith(savedDataset));
   });
 });

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -30,10 +30,9 @@ import {
   saveSolidDatasetAt,
   getSourceUrl,
   hasResourceInfo,
-  getSolidDataset,
 } from "@inrupt/solid-client";
 import { SessionContext } from "../../context/sessionContext";
-import { CommonProperties, useProperty } from "../../helpers";
+import { CommonProperties, updateDataset, useProperty } from "../../helpers";
 
 export type Props = {
   saveDatasetTo?: Url | UrlString;
@@ -125,16 +124,14 @@ export function Text({
             setThing(dataset, updatedResource),
             { fetch }
           );
-          const latestDataset = await getSolidDataset(saveDatasetTo);
-          setDataset(latestDataset);
+          await updateDataset(saveDatasetTo, setDataset);
         } else if (hasResourceInfo(dataset)) {
           savedDataset = await saveSolidDatasetAt(
             getSourceUrl(dataset),
             setThing(dataset, updatedResource),
             { fetch }
           );
-          const latestDataset = await getSolidDataset(getSourceUrl(dataset));
-          setDataset(latestDataset);
+          await updateDataset(getSourceUrl(dataset), setDataset);
         } else {
           setErrorState(() => {
             throw new Error(

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -30,6 +30,7 @@ import {
   saveSolidDatasetAt,
   getSourceUrl,
   hasResourceInfo,
+  getSolidDataset,
 } from "@inrupt/solid-client";
 import { SessionContext } from "../../context/sessionContext";
 import { CommonProperties, useProperty } from "../../helpers";
@@ -124,16 +125,16 @@ export function Text({
             setThing(dataset, updatedResource),
             { fetch }
           );
-
-          setDataset(savedDataset);
+          const latestDataset = await getSolidDataset(saveDatasetTo);
+          setDataset(latestDataset);
         } else if (hasResourceInfo(dataset)) {
           savedDataset = await saveSolidDatasetAt(
             getSourceUrl(dataset),
             setThing(dataset, updatedResource),
             { fetch }
           );
-
-          setDataset(savedDataset);
+          const latestDataset = await getSolidDataset(getSourceUrl(dataset));
+          setDataset(latestDataset);
         } else {
           setErrorState(() => {
             throw new Error(

--- a/src/components/value/boolean/index.test.tsx
+++ b/src/components/value/boolean/index.test.tsx
@@ -48,6 +48,8 @@ const savedDataset = SolidFns.setThing(
   SolidFns.mockSolidDatasetFrom("https://example.pod/resource"),
   SolidFns.createThing()
 );
+const latestDataset = SolidFns.setThing(savedDataset, SolidFns.createThing());
+
 jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataset);
 const mockValue = true;
 
@@ -154,6 +156,7 @@ describe("<BooleanValue /> component functional testing", () => {
     const onSave = jest.fn();
     const onError = jest.fn();
     jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataset);
+    jest.spyOn(SolidFns, "getSolidDataset").mockResolvedValue(latestDataset);
     const { getByDisplayValue } = render(
       <BooleanValue
         solidDataset={mockDatasetWithResourceInfo}
@@ -176,6 +179,7 @@ describe("<BooleanValue /> component functional testing", () => {
     const onSave = jest.fn();
     const onError = jest.fn();
     jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataset);
+    jest.spyOn(SolidFns, "getSolidDataset").mockResolvedValue(latestDataset);
     const { getByDisplayValue } = render(
       <BooleanValue
         solidDataset={mockDatasetWithResourceInfo}
@@ -194,7 +198,7 @@ describe("<BooleanValue /> component functional testing", () => {
     input.blur();
     await waitFor(() => expect(onSave).toHaveBeenCalled());
   });
-  it("Should update the dataset in context after saving", async () => {
+  it("Should update context with latest dataset after saving", async () => {
     const setDataset = jest.fn();
     const setThing = jest.fn();
     jest.spyOn(helpers, "useProperty").mockReturnValue({
@@ -207,6 +211,7 @@ describe("<BooleanValue /> component functional testing", () => {
       property: mockPredicate,
     });
     jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataset);
+    jest.spyOn(SolidFns, "getSolidDataset").mockResolvedValue(latestDataset);
     const { getByDisplayValue } = render(
       <BooleanValue
         solidDataset={mockDatasetWithResourceInfo}
@@ -221,7 +226,7 @@ describe("<BooleanValue /> component functional testing", () => {
     fireEvent.click(input);
     input.blur();
     expect(SolidFns.saveSolidDatasetAt).toHaveBeenCalled();
-    await waitFor(() => expect(setDataset).toHaveBeenCalledWith(savedDataset));
+    await waitFor(() => expect(setDataset).toHaveBeenCalledWith(latestDataset));
   });
   it("Should call onError if saving fails", async () => {
     (SolidFns.saveSolidDatasetAt as jest.Mock).mockRejectedValueOnce(null);

--- a/src/components/value/boolean/index.tsx
+++ b/src/components/value/boolean/index.tsx
@@ -26,6 +26,7 @@ import {
   getSourceUrl,
   hasResourceInfo,
   setBoolean,
+  getSolidDataset,
 } from "@inrupt/solid-client";
 import { SessionContext } from "../../../context/sessionContext";
 
@@ -105,16 +106,16 @@ const BooleanValue: React.FC<BooleanProps> = (props: BooleanProps) => {
             setThing(dataset, updatedResource),
             { fetch }
           );
-
-          setDataset(savedDataset);
+          const latestDataset = await getSolidDataset(saveDatasetTo);
+          setDataset(latestDataset);
         } else if (hasResourceInfo(dataset)) {
           savedDataset = await saveSolidDatasetAt(
             getSourceUrl(dataset),
             setThing(dataset, updatedResource),
             { fetch }
           );
-
-          setDataset(savedDataset);
+          const latestDataset = await getSolidDataset(getSourceUrl(dataset));
+          setDataset(latestDataset);
         } else if (onError) {
           onError(
             new Error("Please provide saveDatasetTo location for new data")

--- a/src/components/value/boolean/index.tsx
+++ b/src/components/value/boolean/index.tsx
@@ -26,11 +26,10 @@ import {
   getSourceUrl,
   hasResourceInfo,
   setBoolean,
-  getSolidDataset,
 } from "@inrupt/solid-client";
 import { SessionContext } from "../../../context/sessionContext";
 
-import { useProperty } from "../../../helpers";
+import { updateDataset, useProperty } from "../../../helpers";
 import { Props } from "..";
 
 type BooleanProps = Omit<Props, "locale" | "dataType">;
@@ -106,16 +105,14 @@ const BooleanValue: React.FC<BooleanProps> = (props: BooleanProps) => {
             setThing(dataset, updatedResource),
             { fetch }
           );
-          const latestDataset = await getSolidDataset(saveDatasetTo);
-          setDataset(latestDataset);
+          await updateDataset(saveDatasetTo, setDataset);
         } else if (hasResourceInfo(dataset)) {
           savedDataset = await saveSolidDatasetAt(
             getSourceUrl(dataset),
             setThing(dataset, updatedResource),
             { fetch }
           );
-          const latestDataset = await getSolidDataset(getSourceUrl(dataset));
-          setDataset(latestDataset);
+          await updateDataset(getSourceUrl(dataset), setDataset);
         } else if (onError) {
           onError(
             new Error("Please provide saveDatasetTo location for new data")

--- a/src/components/value/datetime/index.test.tsx
+++ b/src/components/value/datetime/index.test.tsx
@@ -49,7 +49,10 @@ const savedDataset = SolidFns.setThing(
   SolidFns.mockSolidDatasetFrom("https://example.pod/resource"),
   SolidFns.createThing()
 );
+const latestDataset = SolidFns.setThing(savedDataset, SolidFns.createThing());
+
 jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataset);
+jest.spyOn(SolidFns, "getSolidDataset").mockResolvedValue(latestDataset);
 
 describe("<DatetimeValue /> component functional testing", () => {
   beforeEach(() => {
@@ -278,6 +281,8 @@ describe("<DatetimeValue /> component functional testing", () => {
 
     jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataset);
 
+    jest.spyOn(SolidFns, "getSolidDataset").mockResolvedValue(latestDataset);
+
     const { getByLabelText } = render(
       <DatetimeValue
         solidDataset={mockDatasetWithResourceInfo}
@@ -302,7 +307,7 @@ describe("<DatetimeValue /> component functional testing", () => {
       [mockThing, mockPredicate, expectedDateAndTime],
     ]);
   });
-  it("Should update the dataset in context after saving", async () => {
+  it("Should update context with latest dataset after saving", async () => {
     const setDataset = jest.fn();
     const setThing = jest.fn();
     jest.spyOn(helpers, "useProperty").mockReturnValue({
@@ -329,7 +334,7 @@ describe("<DatetimeValue /> component functional testing", () => {
     input.blur();
     await waitFor(() => {
       expect(SolidFns.saveSolidDatasetAt).toHaveBeenCalled();
-      expect(setDataset).toHaveBeenCalledWith(savedDataset);
+      expect(setDataset).toHaveBeenCalledWith(latestDataset);
     });
   });
 });

--- a/src/components/value/datetime/index.test.tsx
+++ b/src/components/value/datetime/index.test.tsx
@@ -302,4 +302,34 @@ describe("<DatetimeValue /> component functional testing", () => {
       [mockThing, mockPredicate, expectedDateAndTime],
     ]);
   });
+  it("Should update the dataset in context after saving", async () => {
+    const setDataset = jest.fn();
+    const setThing = jest.fn();
+    jest.spyOn(helpers, "useProperty").mockReturnValue({
+      dataset: mockDatasetWithResourceInfo,
+      setDataset,
+      setThing,
+      error: undefined,
+      value: mockBday,
+      thing: mockThing,
+      property: mockPredicate,
+    });
+    const { getByLabelText } = render(
+      <DatetimeValue
+        solidDataset={mockDatasetWithResourceInfo}
+        thing={mockThing}
+        property={mockPredicate}
+        edit
+        autosave
+      />
+    );
+    const input = getByLabelText("Date and Time");
+    input.focus();
+    fireEvent.change(input, { target: { value: "2007-08-14T11:20:00" } });
+    input.blur();
+    await waitFor(() => {
+      expect(SolidFns.saveSolidDatasetAt).toHaveBeenCalled();
+      expect(setDataset).toHaveBeenCalledWith(savedDataset);
+    });
+  });
 });

--- a/src/components/value/datetime/index.tsx
+++ b/src/components/value/datetime/index.tsx
@@ -26,11 +26,14 @@ import {
   getSourceUrl,
   hasResourceInfo,
   setDatetime,
-  getSolidDataset,
 } from "@inrupt/solid-client";
 import { SessionContext } from "../../../context/sessionContext";
 
-import { useProperty, useDatetimeBrowserSupport } from "../../../helpers";
+import {
+  useProperty,
+  useDatetimeBrowserSupport,
+  updateDataset,
+} from "../../../helpers";
 import { Props } from "..";
 
 type DatetimeProps = Omit<Props, "locale" | "dataType">;
@@ -125,18 +128,14 @@ const DatetimeValue: React.FC<DatetimeProps> = (props: DatetimeProps) => {
             setThing(dataset, updatedResource),
             { fetch }
           );
-
-          const latestDataset = await getSolidDataset(saveDatasetTo);
-          setDataset(latestDataset);
+          await updateDataset(saveDatasetTo, setDataset);
         } else if (hasResourceInfo(dataset)) {
           savedDataset = await saveSolidDatasetAt(
             getSourceUrl(dataset),
             setThing(dataset, updatedResource),
             { fetch }
           );
-
-          const latestDataset = await getSolidDataset(getSourceUrl(dataset));
-          setDataset(latestDataset);
+          await updateDataset(getSourceUrl(dataset), setDataset);
         } else if (onError) {
           onError(
             new Error("Please provide saveDatasetTo location for new data")

--- a/src/components/value/datetime/index.tsx
+++ b/src/components/value/datetime/index.tsx
@@ -26,6 +26,7 @@ import {
   getSourceUrl,
   hasResourceInfo,
   setDatetime,
+  getSolidDataset,
 } from "@inrupt/solid-client";
 import { SessionContext } from "../../../context/sessionContext";
 
@@ -125,7 +126,8 @@ const DatetimeValue: React.FC<DatetimeProps> = (props: DatetimeProps) => {
             { fetch }
           );
 
-          setDataset(savedDataset);
+          const latestDataset = await getSolidDataset(saveDatasetTo);
+          setDataset(latestDataset);
         } else if (hasResourceInfo(dataset)) {
           savedDataset = await saveSolidDatasetAt(
             getSourceUrl(dataset),
@@ -133,7 +135,8 @@ const DatetimeValue: React.FC<DatetimeProps> = (props: DatetimeProps) => {
             { fetch }
           );
 
-          setDataset(savedDataset);
+          const latestDataset = await getSolidDataset(getSourceUrl(dataset));
+          setDataset(latestDataset);
         } else if (onError) {
           onError(
             new Error("Please provide saveDatasetTo location for new data")

--- a/src/components/value/decimal/index.test.tsx
+++ b/src/components/value/decimal/index.test.tsx
@@ -49,7 +49,10 @@ const savedDataset = SolidFns.setThing(
   SolidFns.mockSolidDatasetFrom("https://example.pod/resource"),
   SolidFns.createThing()
 );
+const latestDataset = SolidFns.setThing(savedDataset, SolidFns.createThing());
+
 jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataset);
+jest.spyOn(SolidFns, "getSolidDataset").mockResolvedValue(latestDataset);
 
 describe("<DecimalValue /> component functional testing", () => {
   it("calls getDecimal and sets value", () => {
@@ -191,7 +194,7 @@ describe("<DecimalValue /> component functional testing", () => {
     input.blur();
     await waitFor(() => expect(onSave).toHaveBeenCalled());
   });
-  it("Should update the dataset in context after saving", async () => {
+  it("Should update context with latest dataset after saving", async () => {
     const setDataset = jest.fn();
     const setThing = jest.fn();
     jest.spyOn(helpers, "useProperty").mockReturnValue({
@@ -218,7 +221,7 @@ describe("<DecimalValue /> component functional testing", () => {
     input.blur();
     await waitFor(() => {
       expect(SolidFns.saveSolidDatasetAt).toHaveBeenCalled();
-      expect(setDataset).toHaveBeenCalledWith(savedDataset);
+      expect(setDataset).toHaveBeenCalledWith(latestDataset);
     });
   });
 

--- a/src/components/value/decimal/index.test.tsx
+++ b/src/components/value/decimal/index.test.tsx
@@ -23,6 +23,7 @@
 import * as React from "react";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import * as SolidFns from "@inrupt/solid-client";
+import * as helpers from "../../../helpers";
 import DecimalValue from "./index";
 
 const mockPredicate = "http://schema.org/version";
@@ -190,10 +191,51 @@ describe("<DecimalValue /> component functional testing", () => {
     input.blur();
     await waitFor(() => expect(onSave).toHaveBeenCalled());
   });
+  it("Should update the dataset in context after saving", async () => {
+    const setDataset = jest.fn();
+    const setThing = jest.fn();
+    jest.spyOn(helpers, "useProperty").mockReturnValue({
+      dataset: mockDatasetWithResourceInfo,
+      setDataset,
+      setThing,
+      error: undefined,
+      value: mockVersion,
+      thing: mockThing,
+      property: mockPredicate,
+    });
+    const { getByDisplayValue } = render(
+      <DecimalValue
+        solidDataset={mockDatasetWithResourceInfo}
+        thing={mockThing}
+        property={mockPredicate}
+        edit
+        autosave
+      />
+    );
+    const input = getByDisplayValue(mockVersion);
+    input.focus();
+    fireEvent.change(input, { target: { value: testVersion } });
+    input.blur();
+    await waitFor(() => {
+      expect(SolidFns.saveSolidDatasetAt).toHaveBeenCalled();
+      expect(setDataset).toHaveBeenCalledWith(savedDataset);
+    });
+  });
 
   it("Should call onError if Thing not found", async () => {
     (SolidFns.saveSolidDatasetAt as jest.Mock).mockRejectedValueOnce(null);
     const onError = jest.fn();
+    const setDataset = jest.fn();
+    const setThing = jest.fn();
+    jest.spyOn(helpers, "useProperty").mockReturnValueOnce({
+      dataset: mockDatasetWithResourceInfo,
+      setDataset,
+      setThing,
+      error: new Error("Thing not found"),
+      value: null,
+      thing: undefined,
+      property: mockPredicate,
+    });
     render(
       <DecimalValue
         solidDataset={mockDatasetWithResourceInfo}

--- a/src/components/value/decimal/index.tsx
+++ b/src/components/value/decimal/index.tsx
@@ -26,11 +26,10 @@ import {
   getSourceUrl,
   hasResourceInfo,
   setDecimal,
-  getSolidDataset,
 } from "@inrupt/solid-client";
 import { SessionContext } from "../../../context/sessionContext";
 
-import { useProperty } from "../../../helpers";
+import { updateDataset, useProperty } from "../../../helpers";
 import { Props } from "..";
 
 type DecimalProps = Omit<Props, "locale" | "dataType">;
@@ -98,16 +97,14 @@ const DecimalValue: React.FC<DecimalProps> = (props: DecimalProps) => {
             setThing(dataset, updatedResource),
             { fetch }
           );
-          const latestDataset = await getSolidDataset(saveDatasetTo);
-          setDataset(latestDataset);
+          await updateDataset(saveDatasetTo, setDataset);
         } else if (hasResourceInfo(dataset)) {
           savedDataset = await saveSolidDatasetAt(
             getSourceUrl(dataset),
             setThing(dataset, updatedResource),
             { fetch }
           );
-          const latestDataset = await getSolidDataset(getSourceUrl(dataset));
-          setDataset(latestDataset);
+          await updateDataset(getSourceUrl(dataset), setDataset);
         } else if (onError) {
           onError(
             new Error("Please provide saveDatasetTo location for new data")

--- a/src/components/value/decimal/index.tsx
+++ b/src/components/value/decimal/index.tsx
@@ -26,6 +26,7 @@ import {
   getSourceUrl,
   hasResourceInfo,
   setDecimal,
+  getSolidDataset,
 } from "@inrupt/solid-client";
 import { SessionContext } from "../../../context/sessionContext";
 
@@ -97,16 +98,16 @@ const DecimalValue: React.FC<DecimalProps> = (props: DecimalProps) => {
             setThing(dataset, updatedResource),
             { fetch }
           );
-
-          setDataset(savedDataset);
+          const latestDataset = await getSolidDataset(saveDatasetTo);
+          setDataset(latestDataset);
         } else if (hasResourceInfo(dataset)) {
           savedDataset = await saveSolidDatasetAt(
             getSourceUrl(dataset),
             setThing(dataset, updatedResource),
             { fetch }
           );
-
-          setDataset(savedDataset);
+          const latestDataset = await getSolidDataset(getSourceUrl(dataset));
+          setDataset(latestDataset);
         } else if (onError) {
           onError(
             new Error("Please provide saveDatasetTo location for new data")

--- a/src/components/value/integer/index.test.tsx
+++ b/src/components/value/integer/index.test.tsx
@@ -49,7 +49,10 @@ const savedDataset = SolidFns.setThing(
   SolidFns.mockSolidDatasetFrom("https://example.pod/resource"),
   SolidFns.createThing()
 );
+const latestDataset = SolidFns.setThing(savedDataset, SolidFns.createThing());
+
 jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataset);
+jest.spyOn(SolidFns, "getSolidDataset").mockResolvedValue(latestDataset);
 
 describe("<IntegerValue /> component functional testing", () => {
   it("calls getInteger and sets value", () => {
@@ -192,7 +195,7 @@ describe("<IntegerValue /> component functional testing", () => {
     await waitFor(() => expect(onSave).toHaveBeenCalled());
   });
 
-  it("Should update the dataset in context after saving", async () => {
+  it("Should update context with latest dataset after saving", async () => {
     const setDataset = jest.fn();
     const setThing = jest.fn();
     jest.spyOn(helpers, "useProperty").mockReturnValue({
@@ -219,7 +222,7 @@ describe("<IntegerValue /> component functional testing", () => {
     input.blur();
     await waitFor(() => {
       expect(SolidFns.saveSolidDatasetAt).toHaveBeenCalled();
-      expect(setDataset).toHaveBeenCalledWith(savedDataset);
+      expect(setDataset).toHaveBeenCalledWith(latestDataset);
     });
   });
 

--- a/src/components/value/integer/index.tsx
+++ b/src/components/value/integer/index.tsx
@@ -26,6 +26,7 @@ import {
   getSourceUrl,
   hasResourceInfo,
   setInteger,
+  getSolidDataset,
 } from "@inrupt/solid-client";
 import { SessionContext } from "../../../context/sessionContext";
 
@@ -97,8 +98,8 @@ const IntegerValue: React.FC<IntegerProps> = (props: IntegerProps) => {
             setThing(dataset, updatedResource),
             { fetch }
           );
-
-          setDataset(savedDataset);
+          const latestDataset = await getSolidDataset(saveDatasetTo);
+          setDataset(latestDataset);
         } else if (hasResourceInfo(dataset)) {
           savedDataset = await saveSolidDatasetAt(
             getSourceUrl(dataset),
@@ -106,7 +107,8 @@ const IntegerValue: React.FC<IntegerProps> = (props: IntegerProps) => {
             { fetch }
           );
 
-          setDataset(savedDataset);
+          const latestDataset = await getSolidDataset(getSourceUrl(dataset));
+          setDataset(latestDataset);
         } else if (onError) {
           onError(
             new Error("Please provide saveDatasetTo location for new data")

--- a/src/components/value/integer/index.tsx
+++ b/src/components/value/integer/index.tsx
@@ -26,11 +26,10 @@ import {
   getSourceUrl,
   hasResourceInfo,
   setInteger,
-  getSolidDataset,
 } from "@inrupt/solid-client";
 import { SessionContext } from "../../../context/sessionContext";
 
-import { useProperty } from "../../../helpers";
+import { updateDataset, useProperty } from "../../../helpers";
 import { Props } from "..";
 
 type IntegerProps = Omit<Props, "locale" | "dataType">;
@@ -98,17 +97,14 @@ const IntegerValue: React.FC<IntegerProps> = (props: IntegerProps) => {
             setThing(dataset, updatedResource),
             { fetch }
           );
-          const latestDataset = await getSolidDataset(saveDatasetTo);
-          setDataset(latestDataset);
+          await updateDataset(saveDatasetTo, setDataset);
         } else if (hasResourceInfo(dataset)) {
           savedDataset = await saveSolidDatasetAt(
             getSourceUrl(dataset),
             setThing(dataset, updatedResource),
             { fetch }
           );
-
-          const latestDataset = await getSolidDataset(getSourceUrl(dataset));
-          setDataset(latestDataset);
+          await updateDataset(getSourceUrl(dataset), setDataset);
         } else if (onError) {
           onError(
             new Error("Please provide saveDatasetTo location for new data")

--- a/src/components/value/string/index.test.tsx
+++ b/src/components/value/string/index.test.tsx
@@ -23,6 +23,7 @@
 import * as React from "react";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import * as SolidFns from "@inrupt/solid-client";
+import * as helpers from "../../../helpers";
 import StringValue from "./index";
 
 const mockPredicate = `http://xmlns.com/foaf/0.1/nick`;
@@ -266,9 +267,51 @@ describe("<StringValue /> component functional testing", () => {
     await waitFor(() => expect(onSave).toHaveBeenCalled());
   });
 
+  it("Should update the dataset in context after saving", async () => {
+    const setDataset = jest.fn();
+    const setThing = jest.fn();
+    jest.spyOn(helpers, "useProperty").mockReturnValue({
+      dataset: mockDatasetWithResourceInfo,
+      setDataset,
+      setThing,
+      error: undefined,
+      value: mockNick,
+      thing: mockThing,
+      property: mockPredicate,
+    });
+    const { getByDisplayValue } = render(
+      <StringValue
+        solidDataset={mockDatasetWithResourceInfo}
+        thing={mockThing}
+        property={mockPredicate}
+        edit
+        autosave
+      />
+    );
+    const input = getByDisplayValue(mockNick);
+    input.focus();
+    fireEvent.change(input, { target: { value: "test value" } });
+    input.blur();
+    await waitFor(() => {
+      expect(SolidFns.saveSolidDatasetAt).toHaveBeenCalled();
+      expect(setDataset).toHaveBeenCalledWith(savedDataset);
+    });
+  });
+
   it("Should call onError if Thing not found", async () => {
     (SolidFns.saveSolidDatasetAt as jest.Mock).mockRejectedValueOnce(null);
     const onError = jest.fn();
+    const setDataset = jest.fn();
+    const setThing = jest.fn();
+    jest.spyOn(helpers, "useProperty").mockReturnValueOnce({
+      dataset: mockDatasetWithResourceInfo,
+      setDataset,
+      setThing,
+      error: new Error("Thing not found"),
+      value: null,
+      thing: undefined,
+      property: mockPredicate,
+    });
     render(
       <StringValue
         solidDataset={mockDatasetWithResourceInfo}

--- a/src/components/value/string/index.test.tsx
+++ b/src/components/value/string/index.test.tsx
@@ -55,7 +55,10 @@ const savedDataset = SolidFns.setThing(
   SolidFns.mockSolidDatasetFrom("https://example.pod/resource"),
   SolidFns.createThing()
 );
+const latestDataset = SolidFns.setThing(savedDataset, SolidFns.createThing());
+
 jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataset);
+jest.spyOn(SolidFns, "getSolidDataset").mockResolvedValue(latestDataset);
 
 describe("<StringValue /> component functional testing", () => {
   it("calls getStringNoLocale and sets value", () => {
@@ -267,7 +270,7 @@ describe("<StringValue /> component functional testing", () => {
     await waitFor(() => expect(onSave).toHaveBeenCalled());
   });
 
-  it("Should update the dataset in context after saving", async () => {
+  it("Should update context with latest dataset after saving", async () => {
     const setDataset = jest.fn();
     const setThing = jest.fn();
     jest.spyOn(helpers, "useProperty").mockReturnValue({
@@ -294,7 +297,7 @@ describe("<StringValue /> component functional testing", () => {
     input.blur();
     await waitFor(() => {
       expect(SolidFns.saveSolidDatasetAt).toHaveBeenCalled();
-      expect(setDataset).toHaveBeenCalledWith(savedDataset);
+      expect(setDataset).toHaveBeenCalledWith(latestDataset);
     });
   });
 

--- a/src/components/value/string/index.tsx
+++ b/src/components/value/string/index.tsx
@@ -27,6 +27,7 @@ import {
   hasResourceInfo,
   setStringWithLocale,
   setStringNoLocale,
+  getSolidDataset,
 } from "@inrupt/solid-client";
 import { SessionContext } from "../../../context/sessionContext";
 import { useProperty } from "../../../helpers";
@@ -106,7 +107,8 @@ const StringValue: React.FC<StringProps> = (props: StringProps) => {
             { fetch }
           );
 
-          setDataset(savedDataset);
+          const latestDataset = await getSolidDataset(saveDatasetTo);
+          setDataset(latestDataset);
         } else if (hasResourceInfo(dataset)) {
           savedDataset = await saveSolidDatasetAt(
             getSourceUrl(dataset),
@@ -114,7 +116,8 @@ const StringValue: React.FC<StringProps> = (props: StringProps) => {
             { fetch }
           );
 
-          setDataset(savedDataset);
+          const latestDataset = await getSolidDataset(getSourceUrl(dataset));
+          setDataset(latestDataset);
         } else if (onError) {
           onError(
             new Error("Please provide saveDatasetTo location for new data")

--- a/src/components/value/string/index.tsx
+++ b/src/components/value/string/index.tsx
@@ -27,10 +27,9 @@ import {
   hasResourceInfo,
   setStringWithLocale,
   setStringNoLocale,
-  getSolidDataset,
 } from "@inrupt/solid-client";
 import { SessionContext } from "../../../context/sessionContext";
-import { useProperty } from "../../../helpers";
+import { updateDataset, useProperty } from "../../../helpers";
 import { Props } from "..";
 
 type StringProps = Omit<Props, "dataType">;
@@ -106,18 +105,14 @@ const StringValue: React.FC<StringProps> = (props: StringProps) => {
             setThing(dataset, updatedResource),
             { fetch }
           );
-
-          const latestDataset = await getSolidDataset(saveDatasetTo);
-          setDataset(latestDataset);
+          await updateDataset(saveDatasetTo, setDataset);
         } else if (hasResourceInfo(dataset)) {
           savedDataset = await saveSolidDatasetAt(
             getSourceUrl(dataset),
             setThing(dataset, updatedResource),
             { fetch }
           );
-
-          const latestDataset = await getSolidDataset(getSourceUrl(dataset));
-          setDataset(latestDataset);
+          await updateDataset(getSourceUrl(dataset), setDataset);
         } else if (onError) {
           onError(
             new Error("Please provide saveDatasetTo location for new data")

--- a/src/components/value/url/index.test.tsx
+++ b/src/components/value/url/index.test.tsx
@@ -49,7 +49,10 @@ const savedDataset = SolidFns.setThing(
   SolidFns.mockSolidDatasetFrom("https://example.pod/resource"),
   SolidFns.createThing()
 );
+const latestDataset = SolidFns.setThing(savedDataset, SolidFns.createThing());
+
 jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataset);
+jest.spyOn(SolidFns, "getSolidDataset").mockResolvedValue(latestDataset);
 
 describe("<UrlValue /> component functional testing", () => {
   it("calls getUrl and sets value", () => {
@@ -189,7 +192,7 @@ describe("<UrlValue /> component functional testing", () => {
     input.blur();
     await waitFor(() => expect(onSave).toHaveBeenCalled());
   });
-  it("Should update the dataset in context after saving", async () => {
+  it("Should update context with latest dataset after saving", async () => {
     const setDataset = jest.fn();
     const setThing = jest.fn();
     jest.spyOn(helpers, "useProperty").mockReturnValue({
@@ -216,7 +219,7 @@ describe("<UrlValue /> component functional testing", () => {
     input.blur();
     await waitFor(() => {
       expect(SolidFns.saveSolidDatasetAt).toHaveBeenCalled();
-      expect(setDataset).toHaveBeenCalledWith(savedDataset);
+      expect(setDataset).toHaveBeenCalledWith(latestDataset);
     });
   });
 

--- a/src/components/value/url/index.tsx
+++ b/src/components/value/url/index.tsx
@@ -26,11 +26,10 @@ import {
   getSourceUrl,
   hasResourceInfo,
   setUrl,
-  getSolidDataset,
 } from "@inrupt/solid-client";
 import { SessionContext } from "../../../context/sessionContext";
 
-import { useProperty } from "../../../helpers";
+import { updateDataset, useProperty } from "../../../helpers";
 import { Props } from "..";
 
 type UrlProps = Omit<Props, "locale" | "dataType">;
@@ -94,18 +93,14 @@ const UrlValue: React.FC<UrlProps> = (props: UrlProps) => {
             setThing(dataset, updatedResource),
             { fetch }
           );
-
-          const latestDataset = await getSolidDataset(saveDatasetTo);
-          setDataset(latestDataset);
+          await updateDataset(saveDatasetTo, setDataset);
         } else if (hasResourceInfo(dataset)) {
           savedDataset = await saveSolidDatasetAt(
             getSourceUrl(dataset),
             setThing(dataset, updatedResource),
             { fetch }
           );
-
-          const latestDataset = await getSolidDataset(getSourceUrl(dataset));
-          setDataset(latestDataset);
+          await updateDataset(getSourceUrl(dataset), setDataset);
         } else if (onError) {
           onError(
             new Error("Please provide saveDatasetTo location for new data")

--- a/src/components/value/url/index.tsx
+++ b/src/components/value/url/index.tsx
@@ -26,6 +26,7 @@ import {
   getSourceUrl,
   hasResourceInfo,
   setUrl,
+  getSolidDataset,
 } from "@inrupt/solid-client";
 import { SessionContext } from "../../../context/sessionContext";
 
@@ -94,7 +95,8 @@ const UrlValue: React.FC<UrlProps> = (props: UrlProps) => {
             { fetch }
           );
 
-          setDataset(savedDataset);
+          const latestDataset = await getSolidDataset(saveDatasetTo);
+          setDataset(latestDataset);
         } else if (hasResourceInfo(dataset)) {
           savedDataset = await saveSolidDatasetAt(
             getSourceUrl(dataset),
@@ -102,7 +104,8 @@ const UrlValue: React.FC<UrlProps> = (props: UrlProps) => {
             { fetch }
           );
 
-          setDataset(savedDataset);
+          const latestDataset = await getSolidDataset(getSourceUrl(dataset));
+          setDataset(latestDataset);
         } else if (onError) {
           onError(
             new Error("Please provide saveDatasetTo location for new data")

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -40,6 +40,7 @@ import {
   getStringNoLocaleAll,
   getStringWithLocaleAll,
   getUrlAll,
+  getSolidDataset,
 } from "@inrupt/solid-client";
 
 import { useContext, useEffect, useState } from "react";
@@ -367,4 +368,12 @@ export function useDatetimeBrowserSupport(): boolean | null {
   }, []);
 
   return isDatetimeSupported;
+}
+
+export async function updateDataset(
+  datasetUrl: string | Url,
+  setDataset: (dataset: SolidDataset) => void
+): Promise<void> {
+  const latestDataset = await getSolidDataset(datasetUrl);
+  setDataset(latestDataset);
 }


### PR DESCRIPTION
This PR fixes #SDK-1446.

In this PR: 
<del>- Since all the components that save the dataset after changes already set the updated dataset in the context, this PR simply adds tests for this.</del>
- We now fetch the dataset again after saving and before setting it in the context
- Tests updated to reflect this