### PR TITLE
Removed explicit control null configurations

### DIFF
--- a/stories/components/video.stories.tsx
+++ b/stories/components/video.stories.tsx
@@ -34,19 +34,15 @@ export default {
     property: {
       type: { required: true },
       description: `The property of the [Thing](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/glossary/#term-Thing) to retrieve the src URL from.`,
-      control: { type: null },
     },
     edit: {
       description: `If true, renders an input to allow a new video file to be selected.`,
-      control: { type: null },
     },
     autosave: {
       description: `If true, uploads and persists a new video once selected.`,
-      control: { type: null },
     },
     maxSize: {
       description: `The maximum permitted file size, in kB`,
-      control: { type: null },
     },
     inputProps: {
       description: `Additional attributes to be passed to the file input, if \`edit\` is true`,
@@ -71,7 +67,15 @@ export default {
   },
 };
 
-export function EditFalse(): ReactElement {
+export function EditFalse({
+  edit,
+  autosave,
+  maxSize,
+}: {
+  edit: boolean;
+  autosave: boolean;
+  maxSize: number;
+}): ReactElement {
   const exampleUrl =
     "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4";
   const exampleProperty = `http://www.w3.org/2006/vcard/ns#hasPhoto`;
@@ -80,8 +84,23 @@ export function EditFalse(): ReactElement {
     exampleProperty,
     exampleUrl
   );
-  return <Video thing={exampleThing} property={exampleProperty} />;
+  return (
+    <Video
+      thing={exampleThing}
+      property={exampleProperty}
+      edit={edit}
+      autosave={autosave}
+      maxSize={maxSize}
+    />
+  );
 }
+
+EditFalse.args = {
+  edit: false,
+  autosave: false,
+  maxSize: 100,
+  property: "http://www.w3.org/2006/vcard/ns#hasPhoto",
+};
 
 EditFalse.parameters = {
   actions: { disable: true },
@@ -120,6 +139,7 @@ EditTrue.args = {
   edit: true,
   autosave: true,
   maxSize: 100,
+  property: "http://www.w3.org/2006/vcard/ns#hasPhoto",
 };
 
 EditTrue.parameters = {


### PR DESCRIPTION
<!-- When fixing a bug: -->

![Screenshot 2021-06-21 at 11 12 40](https://user-images.githubusercontent.com/4271417/122746170-a8d3d080-d281-11eb-89a6-a7cc76e1578d.png)
![Screenshot 2021-06-21 at 11 12 48](https://user-images.githubusercontent.com/4271417/122746180-ac675780-d281-11eb-9648-abd9b3ca51a5.png)


This PR fixes #[SDK-1966](https://inrupt.atlassian.net/browse/SDK-1966).

Removed the explicit `null` configuration for various controls in storybook in order to have these displayed correctly in voth `view` and `docs` modes

- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

