### PR TITLE
Removed explicit control null configurations for image component

### DIFF
--- a/stories/components/image.stories.tsx
+++ b/stories/components/image.stories.tsx
@@ -37,23 +37,18 @@ export default {
     },
     property: {
       description: `The property of the [Thing](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/glossary/#term-Thing) to retrieve the src URL from.`,
-      control: { type: null },
     },
     properties: {
       description: `An array of ordered properties that will be used to attempt to read the src from (see \`property\`). If there is no value at the first property, the second is attempted, etc, and used for both reading and writing.`,
-      control: { type: null },
     },
     edit: {
       description: `If true, renders an input to allow a new image file to be selected.`,
-      control: { type: null },
     },
     autosave: {
       description: `If true, uploads and persists a new image once selected.`,
-      control: { type: null },
     },
     maxSize: {
       description: `The maximum permitted file size, in kB`,
-      control: { type: null },
     },
     inputProps: {
       description: `Additional attributes to be passed to the file input, if \`edit\` is true`,
@@ -77,32 +72,71 @@ export default {
     },
   },
 };
-
-export function BasicExample(): ReactElement {
-  const property = "http://schema.org/contentUrl";
+interface IWithBasicData {
+  property: string;
+  properties: Array<string>;
+  edit: boolean;
+  maxSize: number;
+}
+export function BasicExample({
+  property,
+  properties,
+  edit,
+  maxSize,
+}: IWithBasicData): ReactElement {
   const thing = addUrl(createThing(), property, `${host}/example.jpg`);
 
-  return <Image thing={thing} property={property} />;
+  return (
+    <Image
+      thing={thing}
+      property={property}
+      properties={properties}
+      edit={edit}
+      maxSize={maxSize}
+    />
+  );
 }
+
+BasicExample.args = {
+  property: "http://schema.org/contentUrl",
+  edit: false,
+  maxSize: 100000000,
+};
 
 BasicExample.parameters = {
   actions: { disable: true },
-  controls: { disable: true },
 };
-
-export function PropertyArrayExample(): ReactElement {
-  const property = "http://schema.org/contentUrl";
-  const notFoundProperty = "http://schema.org/iri-not-on-the-thing";
+export function PropertyArrayExample({
+  property,
+  properties,
+  edit,
+  maxSize,
+}: IWithBasicData): ReactElement {
   const thing = addUrl(createThing(), property, `${host}/example.jpg`);
 
-  return <Image thing={thing} properties={[notFoundProperty, property]} />;
+  return (
+    <Image
+      thing={thing}
+      properties={properties}
+      edit={edit}
+      maxSize={maxSize}
+    />
+  );
 }
+
+PropertyArrayExample.args = {
+  property: "http://schema.org/contentUrl",
+  properties: [
+    "http://schema.org/iri-not-on-the-thing",
+    "http://schema.org/contentUrl",
+  ],
+  edit: false,
+  maxSize: 100000000,
+};
 
 PropertyArrayExample.parameters = {
   actions: { disable: true },
-  controls: { disable: true },
 };
-
 interface IWithDatasetProvider {
   datasetUrl: string;
   thingUrl: string;
@@ -134,7 +168,6 @@ WithDatasetProvider.args = {
 
 WithDatasetProvider.parameters = {
   actions: { disable: true },
-  controls: { disable: true },
 };
 
 export function ErrorComponent(): ReactElement {
@@ -152,5 +185,4 @@ export function ErrorComponent(): ReactElement {
 
 ErrorComponent.parameters = {
   actions: { disable: true },
-  controls: { disable: true },
 };


### PR DESCRIPTION
<!-- When fixing a bug: -->

This PR fixes #[SDK-2115](https://inrupt.atlassian.net/browse/SDK-2115).

<img width="1382" alt="Screenshot 2021-06-22 at 11 05 27" src="https://user-images.githubusercontent.com/4271417/122906161-c3717c80-d349-11eb-9e2f-6fdd50000998.png">
<img width="1001" alt="Screenshot 2021-06-22 at 11 05 16" src="https://user-images.githubusercontent.com/4271417/122906207-d1270200-d349-11eb-838b-cb8e09a39cae.png">

- Removed explicit `null` config for various controls
- Added `interface` and data args for each example to enable control options


- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

