### PR TITLE
Feature/table component empty state fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+- `Table` now takes an optional `noDataComponent` to be rendered if no columns are present.
+
 - `TableColumn` now takes an optional `sortFn` sorting function used to sort that column.
 
 - The following components now take an optional `loadingComponent` to be rendered while fetching data:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
-- `Table` now takes an optional `noDataComponent` to be rendered if no columns are present.
+- `Table` now takes an optional `emptyStateComponent` to be rendered if no columns are present.
 
 - `TableColumn` now takes an optional `sortFn` sorting function used to sort that column.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
-- `Table` now takes an optional `emptyStateComponent` to be rendered if no columns are present.
+- `Table` now takes an optional `emptyStateComponent` to be rendered if no rows are present.
 
 - `TableColumn` now takes an optional `sortFn` sorting function used to sort that column.
 

--- a/src/components/table/index.test.tsx
+++ b/src/components/table/index.test.tsx
@@ -309,7 +309,7 @@ describe("<Table /> component functional tests", () => {
     expect(queryByText(/multiple nick 2/)).toBeNull();
   });
 
-  it("renders fallback component when passed and there are no columns", () => {
+  it("renders fallback component when passed and there are no rows", () => {
     const { getByText } = render(
       <Table
         things={[

--- a/src/components/table/index.test.tsx
+++ b/src/components/table/index.test.tsx
@@ -316,7 +316,7 @@ describe("<Table /> component functional tests", () => {
           { dataset, thing: thing1 },
           { dataset, thing: thing2 },
         ]}
-        noDataComponent={() => <span>There is no Data</span>}
+        emptyStateComponent={() => <span>There is no Data</span>}
       />
     );
 

--- a/src/components/table/index.test.tsx
+++ b/src/components/table/index.test.tsx
@@ -308,4 +308,18 @@ describe("<Table /> component functional tests", () => {
     expect(getByText(/multiple nick 1/)).not.toBeNull();
     expect(queryByText(/multiple nick 2/)).toBeNull();
   });
+
+  it("renders fallback component when passed and there are no columns", () => {
+    const { getByText } = render(
+      <Table
+        things={[
+          { dataset, thing: thing1 },
+          { dataset, thing: thing2 },
+        ]}
+        noDataComponent={() => <span>There is no Data</span>}
+      />
+    );
+
+    expect(getByText(/There is no Data/)).not.toBeNull();
+  });
 });

--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -93,42 +93,44 @@ export function Table({
 
     // loop through each column
     Children.forEach(children, (column, colIndex) => {
-      const {
-        property,
-        header,
-        body,
-        dataType = "string",
-        locale,
-        multiple = false,
-        sortable,
-        sortFn,
-        filterable,
-      } = column.props;
-      // add heading
+      if (column) {
+        const {
+          property,
+          header,
+          body,
+          dataType = "string",
+          locale,
+          multiple = false,
+          sortable,
+          sortFn,
+          filterable,
+        } = column.props;
+        // add heading
 
-      columnsArray.push({
-        Header: header ?? `${property}`,
-        accessor: `col${colIndex}`,
-        disableGlobalFilter: !filterable,
-        disableSortBy: !sortable,
-        Cell: body ?? (({ value }: any) => (value != null ? `${value}` : "")),
-      });
+        columnsArray.push({
+          Header: header ?? `${property}`,
+          accessor: `col${colIndex}`,
+          disableGlobalFilter: !filterable,
+          disableSortBy: !sortable,
+          Cell: body ?? (({ value }: any) => (value != null ? `${value}` : "")),
+        });
 
-      if (sortFn) {
-        const sortFunction = (a: Row, b: Row, columnId: string) => {
-          const valueA = a.values[columnId];
-          const valueB = b.values[columnId];
-          return sortFn(valueA, valueB);
-        };
-        columnsArray[colIndex].sortType = sortFunction;
+        if (sortFn) {
+          const sortFunction = (a: Row, b: Row, columnId: string) => {
+            const valueA = a.values[columnId];
+            const valueB = b.values[columnId];
+            return sortFn(valueA, valueB);
+          };
+          columnsArray[colIndex].sortType = sortFunction;
+        }
+
+        // add each each value to data
+        things.forEach((thing, i) => {
+          dataArray[i][`col${colIndex}`] = multiple
+            ? getValueByTypeAll(dataType, thing.thing, property, locale)
+            : getValueByType(dataType, thing.thing, property, locale);
+        });
       }
-
-      // add each each value to data
-      things.forEach((thing, i) => {
-        dataArray[i][`col${colIndex}`] = multiple
-          ? getValueByTypeAll(dataType, thing.thing, property, locale)
-          : getValueByType(dataType, thing.thing, property, locale);
-      });
     });
 
     return { columns: columnsArray, data: dataArray };

--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -59,9 +59,10 @@ export function TableColumn(props: TableColumnProps): ReactElement {
 
 export interface TableProps
   extends React.TableHTMLAttributes<HTMLTableElement> {
-  children:
+  children?:
     | ReactElement<TableColumnProps>
     | Array<ReactElement<TableColumnProps>>;
+  noDataComponent?: React.ComponentType | null;
   things: Array<{ dataset: SolidDataset; thing: Thing }>;
   filter?: string;
   ascIndicator?: ReactNode;
@@ -78,13 +79,14 @@ export interface TableProps
  */
 export function Table({
   children,
+  noDataComponent: NoDataComponent,
   things,
   filter,
   ascIndicator,
   descIndicator,
   getRowProps,
   ...tableProps
-}: TableProps): ReactElement {
+}: TableProps): ReactElement | null {
   const { columns, data } = useMemo(() => {
     const columnsArray: Array<Column<Record<string, unknown>>> = [];
     const dataArray: Array<Record<string, unknown>> = things.map(() => ({}));
@@ -149,6 +151,12 @@ export function Table({
     rows,
     prepareRow,
   } = tableInstance;
+  if (!rows.length) {
+    if (NoDataComponent) {
+      return <NoDataComponent />;
+    }
+    return null;
+  }
   return (
     <table {...getTableProps()} {...tableProps}>
       <thead>

--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -62,7 +62,7 @@ export interface TableProps
   children?:
     | ReactElement<TableColumnProps>
     | Array<ReactElement<TableColumnProps>>;
-  noDataComponent?: React.ComponentType | null;
+  emptyStateComponent?: React.ComponentType | null;
   things: Array<{ dataset: SolidDataset; thing: Thing }>;
   filter?: string;
   ascIndicator?: ReactNode;
@@ -79,7 +79,7 @@ export interface TableProps
  */
 export function Table({
   children,
-  noDataComponent: NoDataComponent,
+  emptyStateComponent: EmptyStateComponent,
   things,
   filter,
   ascIndicator,
@@ -154,8 +154,8 @@ export function Table({
     prepareRow,
   } = tableInstance;
   if (!rows.length) {
-    if (NoDataComponent) {
-      return <NoDataComponent />;
+    if (EmptyStateComponent) {
+      return <EmptyStateComponent />;
     }
     return null;
   }

--- a/stories/components/table.stories.tsx
+++ b/stories/components/table.stories.tsx
@@ -52,6 +52,10 @@ export default {
       description: `Function which is passed the [row](https://react-table.tanstack.com/docs/api/useTable#row-properties) object, as well as the [Thing](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/glossary/#term-Thing) and [Dataset](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/glossary/#term-SolidDataset) for the current row. Returns an object of attributes to be applied to the <tr>`,
       control: { type: null },
     },
+    noDataComponent: {
+      description: `An empty state component to show the table has no rows. If \`null\` the default empty state render is \`null\``,
+      control: { type: null },
+    },
   },
 };
 
@@ -439,22 +443,21 @@ FilterOnFirstColumn.args = {
 FilterOnFirstColumn.parameters = {
   actions: { disable: true },
 };
-
-export function SortingFunctionOnFirstColumn(): ReactElement {
+export function NoDataComponent(): ReactElement {
   const namePredicate = `http://xmlns.com/foaf/0.1/name`;
   const datePredicate = `http://schema.org/datePublished`;
 
   const thing1A = SolidFns.addStringNoLocale(
     SolidFns.createThing(),
     namePredicate,
-    "Another Name"
+    `example name 1`
   );
   const thing1 = SolidFns.addDatetime(thing1A, datePredicate, new Date());
 
   const thing2A = SolidFns.addStringNoLocale(
     SolidFns.createThing(),
     namePredicate,
-    "Name A"
+    `example name 2`
   );
   const thing2 = SolidFns.addDatetime(
     thing2A,
@@ -466,32 +469,18 @@ export function SortingFunctionOnFirstColumn(): ReactElement {
   const datasetWithThing1 = SolidFns.setThing(emptyDataset, thing1);
   const dataset = SolidFns.setThing(datasetWithThing1, thing2);
 
-  const sortFunction = (a: string, b: string) => {
-    const valueA = a.split(/\s+/)[1];
-    const valueB = b.split(/\s+/)[1];
-    return valueA.localeCompare(valueB);
-  };
-
   return (
     <Table
       things={[
-        {
-          dataset,
-          thing: thing1,
-        },
-        {
-          dataset,
-          thing: thing2,
-        },
+        { dataset, thing: thing1 },
+        { dataset, thing: thing2 },
       ]}
       style={{ border: "1px solid black" }}
-    >
-      <TableColumn property={namePredicate} sortable sortFn={sortFunction} />
-      <TableColumn property={datePredicate} dataType="datetime" />
-    </Table>
+      noDataComponent={() => <span>There is no Data</span>}
+    />
   );
 }
 
-SortingFunctionOnFirstColumn.parameters = {
+NoDataComponent.parameters = {
   actions: { disable: true },
 };

--- a/stories/components/table.stories.tsx
+++ b/stories/components/table.stories.tsx
@@ -443,6 +443,62 @@ FilterOnFirstColumn.args = {
 FilterOnFirstColumn.parameters = {
   actions: { disable: true },
 };
+
+export function SortingFunctionOnFirstColumn(): ReactElement {
+  const namePredicate = `http://xmlns.com/foaf/0.1/name`;
+  const datePredicate = `http://schema.org/datePublished`;
+
+  const thing1A = SolidFns.addStringNoLocale(
+    SolidFns.createThing(),
+    namePredicate,
+    "Another Name"
+  );
+  const thing1 = SolidFns.addDatetime(thing1A, datePredicate, new Date());
+
+  const thing2A = SolidFns.addStringNoLocale(
+    SolidFns.createThing(),
+    namePredicate,
+    "Name A"
+  );
+  const thing2 = SolidFns.addDatetime(
+    thing2A,
+    datePredicate,
+    new Date("1999-01-02")
+  );
+
+  const emptyDataset = SolidFns.createSolidDataset();
+  const datasetWithThing1 = SolidFns.setThing(emptyDataset, thing1);
+  const dataset = SolidFns.setThing(datasetWithThing1, thing2);
+
+  const sortFunction = (a: string, b: string) => {
+    const valueA = a.split(/\s+/)[1];
+    const valueB = b.split(/\s+/)[1];
+    return valueA.localeCompare(valueB);
+  };
+
+  return (
+    <Table
+      things={[
+        {
+          dataset,
+          thing: thing1,
+        },
+        {
+          dataset,
+          thing: thing2,
+        },
+      ]}
+      style={{ border: "1px solid black" }}
+    >
+      <TableColumn property={namePredicate} sortable sortFn={sortFunction} />
+      <TableColumn property={datePredicate} dataType="datetime" />
+    </Table>
+  );
+}
+
+SortingFunctionOnFirstColumn.parameters = {
+  actions: { disable: true },
+};
 export function NoDataComponent(): ReactElement {
   const namePredicate = `http://xmlns.com/foaf/0.1/name`;
   const datePredicate = `http://schema.org/datePublished`;

--- a/stories/components/table.stories.tsx
+++ b/stories/components/table.stories.tsx
@@ -52,7 +52,7 @@ export default {
       description: `Function which is passed the [row](https://react-table.tanstack.com/docs/api/useTable#row-properties) object, as well as the [Thing](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/glossary/#term-Thing) and [Dataset](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/glossary/#term-SolidDataset) for the current row. Returns an object of attributes to be applied to the <tr>`,
       control: { type: null },
     },
-    noDataComponent: {
+    emptyStateComponent: {
       description: `An empty state component to show the table has no rows. If \`null\` the default empty state render is \`null\``,
       control: { type: null },
     },
@@ -532,7 +532,7 @@ export function NoDataComponent(): ReactElement {
         { dataset, thing: thing2 },
       ]}
       style={{ border: "1px solid black" }}
-      noDataComponent={() => <span>There is no Data</span>}
+      emptyStateComponent={() => <span>There is no Data</span>}
     />
   );
 }


### PR DESCRIPTION
<!-- When adding a new feature: -->

# `noDataComponent` fallback for the `Table` component

This PR addresses ticket SDK-1502

In this PR:

- Table component now takes an optional `noDataComponent` to be rendered when there are no columns.
- By default, if no fallback is passed the table won't render and `null` is returned


# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [ ] New functions/types have been exported in `index.ts`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).


[SDK-1502]: https://inrupt.atlassian.net/browse/SDK-1502