### PR TITLE
Fix: ignore capitalization by default when sorting

### DIFF
--- a/src/components/table/index.test.tsx
+++ b/src/components/table/index.test.tsx
@@ -143,6 +143,40 @@ describe("<Table /> component functional tests", () => {
     expect(queryByText("🔼")).toBeNull();
   });
 
+  it("ignored capitalization when sorting", () => {
+    const thingA = SolidFns.addStringNoLocale(
+      SolidFns.createThing(),
+      namePredicate,
+      "example"
+    );
+    const thingB = SolidFns.addStringNoLocale(
+      SolidFns.createThing(),
+      namePredicate,
+      "Foo"
+    );
+    const datasetWithThingA = SolidFns.setThing(
+      SolidFns.createSolidDataset(),
+      thingA
+    );
+    const datasetToSort = SolidFns.setThing(datasetWithThingA, thingB);
+
+    const { getByText, queryAllByRole } = render(
+      <Table
+        things={[
+          { dataset: datasetToSort, thing: thingB },
+          { dataset: datasetToSort, thing: thingA },
+        ]}
+      >
+        <TableColumn property={namePredicate} sortable />
+      </Table>
+    );
+    expect(queryAllByRole("cell")[0].innerHTML).toBe("Foo");
+    expect(queryAllByRole("cell")[1].innerHTML).toBe("example");
+    fireEvent.click(getByText(namePredicate));
+    expect(queryAllByRole("cell")[0].innerHTML).toBe("example");
+    expect(queryAllByRole("cell")[1].innerHTML).toBe("Foo");
+  });
+
   it("uses sortFn for sorting if passed", () => {
     const thingA = SolidFns.addStringNoLocale(
       SolidFns.createThing(),

--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -122,6 +122,13 @@ export function Table({
             return sortFn(valueA, valueB);
           };
           columnsArray[colIndex].sortType = sortFunction;
+        } else {
+          if (dataType === "string") {
+            columnsArray[colIndex].sortType = dataType;
+          }
+          if (dataType === "integer" || dataType === "decimal") {
+            columnsArray[colIndex].sortType = "number";
+          }
         }
 
         // add each each value to data


### PR DESCRIPTION
This PR fixes #SDK-1574.

React Table by default sorts by ASCII, not alphabetically, so this means that capitalized strings will come first in the sorting. To fix this, React Table has introduced two built-in sort types: https://github.com/tannerlinsley/react-table/pull/3235

In this PR, those two built-in sort types are used when the dataType is either a string or a number (integer or decimal), and the sort function is not passed.

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
