### PR TITLE
Change target from commonjs to umd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+- Change build target from commonjs to umd
+
 ## 2.4.1 ( August 18, 2021 )
 
 - Fix missing code snippets in storybook

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = {
   },
   output: {
     filename: "index.js",
-    libraryTarget: "commonjs"
+    libraryTarget: "umd"
   },
   plugins: [
     new CleanWebpackPlugin(),


### PR DESCRIPTION
This PR fixes #427.

I’ve traced to this the upgrade to webpack 5 (nothing to do with the changes in 2.4.1 - as it’s webpack issue it only seems to show up when importing the module to another project, not when running e.g. the storybook examples)

A similar issue is described here: https://github.com/webpack/webpack/issues/11277, and the fix some people found (output umd rather than commonjs) seems to work for me with the react sdk. Anyone have any thoughts/objections to changing that target (umd should support commonjs usage)?

- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).