### PR TITLE
Fix: pass revalidateOnFocus option to useSWR to reduce number of requ…

### DIFF
--- a/src/hooks/useDataset/index.tsx
+++ b/src/hooks/useDataset/index.tsx
@@ -45,6 +45,9 @@ export default function useDataset(
       };
       // useSWR will only call this fetcher if datasetUri is defined
       return getSolidDataset(datasetIri as string, requestOptions);
+    },
+    {
+      revalidateOnFocus: false,
     }
   );
 


### PR DESCRIPTION
This PR fixes performance issue identified during the performance review of PB

The `useDataset` hook was re-fetching the dataset whenever the window was unfocused and then refocused. To prevent unnecessary requests, this PR adds the passing of `revalidateOnFocus` set to `false` to the `useSWR` hook. 

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
