### PR TITLE
Fix: set error value correctly in Image component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Bugfixes
+
+- When `Image` component is editable, the value error will be set if there is no image available, which means the error component (default or custom) wis displayed correctly. 
+
 ## 2.7.0 ( January 20, 2022 )
 
 ### New features

--- a/src/components/image/index.tsx
+++ b/src/components/image/index.tsx
@@ -79,7 +79,7 @@ export function Image({
 
   const { value, thing, error: thingError } = values;
   let valueError;
-  if (!edit && !value) {
+  if (!value) {
     valueError = new Error("No value found for property.");
   }
   const isFetchingThing = !thing && !thingError;


### PR DESCRIPTION
There was a condition that checked if Image was in edit mode, in which case the value error wasn't set. This was incorrect, so this PR removed that check so value error is set regardless of edit mode, so we can display a fallback or error component if an image isn't found.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
