### PR TITLE
Integrate Sonar analysis with test coverage on PRs into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,10 @@ jobs:
         with:
           name: code-coverage-report
           path: coverage
+      - run: git fetch --unshallow
+        if: ${{ matrix.node-version == '16.x' && matrix.os == 'ubuntu-latest' }}
+      - uses: SonarSource/sonarcloud-github-action@v1.6
+        if: ${{ matrix.node-version == '16.x' && matrix.os == 'ubuntu-latest' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,12 @@ jobs:
         with:
           name: code-coverage-report
           path: coverage
+
+      # Sonar analysis needs the full history for features like automatic assignment of bugs. If the following step
+      # is not included the project will show a warning about incomplete information.
       - run: git fetch --unshallow
         if: ${{ matrix.node-version == '16.x' && matrix.os == 'ubuntu-latest' }}
+      # Run Sonar analysis on just the latest ubuntu/node runner.
       - uses: SonarSource/sonarcloud-github-action@v1.6
         if: ${{ matrix.node-version == '16.x' && matrix.os == 'ubuntu-latest' }}
         env:

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
   ],
 
   collectCoverage: true,
+  coverageReporters: process.env.CI ? ["text", "lcov"] : ["text"],
 
   coveragePathIgnorePatterns: [
     "/node_modules/",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,16 @@
+sonar.projectKey=inrupt_solid-ui-react
+sonar.organization=inrupt
+
+# Path is relative to the sonar-project.properties file. Defaults to .
+sonar.sources=src
+
+# Path to Tests and coverage results
+#sonar.tests=test
+
+# Typescript tsconfigPath JSON file
+sonar.typescript.tsconfigPath=.
+
+# Comma-delimited list of paths to LCOV coverage report files. Paths may be absolute or relative to the project root.
+sonar.javascript.lcov.reportPaths=./coverage/lcov.info
+
+sonar.exclusions=**/*.test.ts


### PR DESCRIPTION
This extends the CI workflow to run a SonarCloud Scan on each PR, including unit tests and the coverage report. The results are added to SonarCloud.