### PR TITLE
ci: correctly exclude tests from Sonarcloud

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,14 +3,15 @@ sonar.organization=inrupt
 
 # Path is relative to the sonar-project.properties file. Defaults to .
 sonar.sources=src
+sonar.exclusions=**/*.test.ts,**/*.test.tsx,**/__snapshots__/*
 
-# Path to Tests and coverage results
-#sonar.tests=test
+sonar.tests=src
+sonar.test.inclusions=**/*.test.ts,**/*.test.tsx,**/__snapshots__/*
+
+sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx,**/__snapshots__/*
 
 # Typescript tsconfigPath JSON file
 sonar.typescript.tsconfigPath=.
 
 # Comma-delimited list of paths to LCOV coverage report files. Paths may be absolute or relative to the project root.
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
-
-sonar.exclusions=**/*.test.ts


### PR DESCRIPTION
This should fix the issue with Sonarcloud showing 0% coverage for test files