### PR TITLE
Disable sonar scans on dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,21 @@ jobs:
           name: code-coverage-report
           path: coverage
 
-      # Sonar analysis needs the full history for features like automatic assignment of bugs. If the following step
-      # is not included the project will show a warning about incomplete information.
-      - run: git fetch --unshallow
-        if: ${{ matrix.node-version == '16.x' && matrix.os == 'ubuntu-latest' }}
-      # Run Sonar analysis on just the latest ubuntu/node runner.
+  sonar-scan:
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Sonar analysis needs the full history for features like automatic assignment of bugs. If the following step
+          # is not included the project will show a warning about incomplete information.
+          fetch-depth: 0
+      - uses: actions/download-artifact@v3
+        with:
+          name: code-coverage-report
+          path: coverage/
       - uses: SonarSource/sonarcloud-github-action@v1.6
-        if: ${{ matrix.node-version == '16.x' && matrix.os == 'ubuntu-latest' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Dependabot cannot access repository secrets, including the sonar cloud token.

