### PR TITLE
feat: include sourcemap & changelog in package contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "dist/index.js",
   "types": "dist/src/index.d.ts",
   "files": [
+    "CHANGELOG.md",
     "dist/index.js",
+    "dist/index.js.map",
     "dist/src/*",
     "dist/src/**/*"
   ],


### PR DESCRIPTION
This PR fixes the warning/error that people using create-react-app were seeing about failing to load a source map.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
