### PR TITLE
feat: allow skipping loading the profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Added the ability to prevent the automatic loading of WebID's and Profiles from SessionProvider, this is useful when building provisioning applications where the user has logged in, but doesn't yet have a WebID or Pod or Profile documents.
+
 ## 2.8.1 ( October 10, 2022)
 
 - Upgrade Inrupt SDKs to latest versions

--- a/stories/authentication/sessionProvider.stories.tsx
+++ b/stories/authentication/sessionProvider.stories.tsx
@@ -20,6 +20,8 @@
  */
 
 import React, { ReactElement, useContext, useState } from "react";
+import { ComponentMeta } from "@storybook/react";
+
 import {
   SessionContext,
   SessionProvider,
@@ -65,8 +67,12 @@ export default {
       description: `Function to be called on session restore. It is invoked with the URL of the refreshed page as its parameter`,
       control: { type: null },
     },
+    skipLoadingProfile: {
+      description: `**Experimental:** When set to true, prevents the SessionProvider from automatically loading the WebID / Profiles`,
+      defaultValue: false,
+    },
   },
-};
+} as ComponentMeta<typeof SessionProvider>;
 
 function Dashboard(): ReactElement {
   const { session, sessionRequestInProgress } = useContext(SessionContext);


### PR DESCRIPTION
Currently when using `<SessionProvider>` it automatically tries to load the WebID & associated Profile Documents, in most applications, this is okay, but when building a start/provisioning application, this behaviour is not desirable as the user does not yet have a WebID or Profile.

This change adds an experimental prop to `<SessionProvider>` that allows disabling the automatic loading of profiles. This prop is considered experimental as the API has not yet stabilised and may change in a future major version.

# Usage

```
<SessionProvider skipLoadingProfile>
  ...
</SessionProvider>
```

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [ ] New functions/types have been exported in `index.ts`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
