### PR TITLE
Expose `useSWR` return values in `useDataset` and `useThing`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Expose `useSWR` return values in `useDataset` and `useThing`
+
 ## 2.8.1 ( October 10, 2022)
 
 - Upgrade Inrupt SDKs to latest versions

--- a/src/hooks/useDataset/index.test.tsx
+++ b/src/hooks/useDataset/index.test.tsx
@@ -20,7 +20,7 @@
  */
 
 import * as React from "react";
-import { renderHook } from "@testing-library/react-hooks";
+import { act, renderHook } from "@testing-library/react-hooks";
 import { SWRConfig } from "swr";
 import * as SolidFns from "@inrupt/solid-client";
 import { Session } from "@inrupt/solid-client-authn-browser";
@@ -126,5 +126,20 @@ describe("useDataset() hook", () => {
     await waitFor(() =>
       expect(result.current.dataset).toBe(mockContextDataset)
     );
+  });
+
+  it("should refetch dataset when mutate is called", async () => {
+    const { result, waitFor } = renderHook(() => useDataset(mockDatasetIri), {
+      wrapper,
+    });
+
+    expect(mockGetSolidDataset).toHaveBeenCalledTimes(1);
+    expect(mockGetSolidDataset).toHaveBeenCalledWith(mockDatasetIri, {
+      fetch: mockFetch,
+    });
+    await waitFor(() => expect(result.current.dataset).toBe(mockDataset));
+
+    await act(() => result.current.mutate());
+    expect(mockGetSolidDataset).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/hooks/useDataset/index.test.tsx
+++ b/src/hooks/useDataset/index.test.tsx
@@ -32,9 +32,7 @@ describe("useDataset() hook", () => {
   const mockDatasetIri = "https://mock.url";
   const mockDataset = SolidFns.mockSolidDatasetFrom(mockDatasetIri);
   const mockContextDataset = SolidFns.mockSolidDatasetFrom(mockDatasetIri);
-  const mockGetSolidDataset = jest
-    .spyOn(SolidFns, "getSolidDataset")
-    .mockResolvedValue(mockDataset);
+  const mockGetSolidDataset = jest.spyOn(SolidFns, "getSolidDataset");
 
   const mockFetch = jest.fn();
 
@@ -62,8 +60,9 @@ describe("useDataset() hook", () => {
     </SWRConfig>
   );
 
-  afterEach(() => {
+  beforeEach(() => {
     jest.clearAllMocks();
+    mockGetSolidDataset.mockResolvedValue(mockDataset);
   });
 
   it("should call getSolidDataset with given Iri", async () => {

--- a/src/hooks/useDataset/index.tsx
+++ b/src/hooks/useDataset/index.tsx
@@ -20,23 +20,25 @@
  */
 
 import { useContext } from "react";
-import useSWR from "swr";
+import useSWR , { SWRResponse } from "swr";
 import { getSolidDataset, SolidDataset } from "@inrupt/solid-client";
 import { SessionContext } from "../../context/sessionContext";
 import DatasetContext from "../../context/datasetContext";
+
+type UseDatasetReturnType = Omit<SWRResponse, 'data'> & {
+  dataset?: SolidDataset;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  error: any;
+}
 
 export default function useDataset(
   datasetIri?: string | null | undefined,
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
   options?: any
-): {
-  dataset: SolidDataset | undefined;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  error: any;
-} {
+): UseDatasetReturnType {
   const { fetch } = useContext(SessionContext);
   const { solidDataset: datasetFromContext } = useContext(DatasetContext);
-  const { data, error } = useSWR(
+  const { data, error, ...rest } = useSWR(
     datasetIri ? [datasetIri, options, fetch] : null,
     () => {
       const requestOptions = {
@@ -49,5 +51,5 @@ export default function useDataset(
   );
 
   const dataset = datasetIri ? (data as SolidDataset) : datasetFromContext;
-  return { dataset, error };
+  return { dataset, error, ...rest };
 }

--- a/src/hooks/useThing/index.tsx
+++ b/src/hooks/useThing/index.tsx
@@ -24,23 +24,26 @@ import { useContext } from "react";
 import ThingContext from "../../context/thingContext";
 import useDataset from "../useDataset";
 
+type UseThingReturnType = ReturnType<typeof useDataset> & {
+  thing?: Thing | null;
+};
+
 export default function useThing(
   datasetIri?: string | null | undefined,
   thingIri?: string | null | undefined,
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
   options?: any
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): { thing?: Thing | null; error: any } {
-  const { dataset, error } = useDataset(datasetIri, options);
+): UseThingReturnType {
+  const { dataset, ...rest } = useDataset(datasetIri, options);
   const { thing: thingFromContext } = useContext(ThingContext);
   if (!thingIri) {
-    return { thing: thingFromContext || undefined, error };
+    return { dataset, thing: thingFromContext || undefined, ...rest };
   }
 
   if (!dataset) {
-    return { thing: null, error };
+    return { dataset, thing: null, ...rest };
   }
 
   const thing = getThing(dataset, thingIri);
-  return { thing, error };
+  return { dataset, thing, ...rest };
 }

--- a/stories/hooks/useDataset.stories.mdx
+++ b/stories/hooks/useDataset.stories.mdx
@@ -21,6 +21,8 @@ const { thing, error } = useDataset(datasetIri, options)
 
 - `dataset`: the [Dataset](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/glossary/#term-SolidDataset) retrieved from context or request using given [IRI](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/glossary/#term-IRI) (undefined if loading/missing)
 - `error`: the error thrown by the request (or undefined)
+- `isValidating`: if there's a request or revalidation loading
+- `mutate(data?, options?)`: function to mutate the cached data ([details](https://swr.vercel.app/docs/mutation))
 
 ## Example Usage
 

--- a/stories/hooks/useThing.stories.mdx
+++ b/stories/hooks/useThing.stories.mdx
@@ -21,8 +21,11 @@ const { thing, error } = useThing(datasetIri, thingIri, options)
 
 ## Return Values
 
+- `dataset`: the [Dataset](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/glossary/#term-SolidDataset) retrieved from context or request using given [IRI](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/glossary/#term-IRI) (undefined if loading/missing)
 - `thing`: the [Thing](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/glossary/#term-Thing) retrieved from context or requests using given [IRI](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/glossary/#term-IRI) (undefined if loading/missing)
 - `error`: the error thrown by the request (or undefined)
+- `isValidating`: if there's a request or revalidation loading
+- `mutate(data?, options?)`: function to mutate the cached data ([details](https://swr.vercel.app/docs/mutation))
 
 ## Example Usage
 


### PR DESCRIPTION
# New feature description
This PR exposes two additional fields, `mutate` and `isValidating`, from `useSWR` to the consumers of `useDataset` and `useThing`.

It also exposes the `dataset` field to consumers of `useThing`.

# Context
As they are, `useDataset` and `useThing` are useful abstractions for retrieving data, but currently are bit lacking when wanting to then update, or force a refresh on those items.  `useSWR` provides this functionality via the bound ([mutate](https://swr.vercel.app/docs/mutation)) function it returns, but this currently isn't being exposed.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
