### PR TITLE
Chore/upgrade sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client": "^1.25.0",
-        "@inrupt/solid-client-authn-browser": "^1.12.3",
+        "@inrupt/solid-client-authn-browser": "^1.13.0",
         "core-js": "^3.18.3",
         "react-table": "^7.6.3",
         "stream": "0.0.2",
@@ -2679,12 +2679,12 @@
       }
     },
     "node_modules/@inrupt/oidc-client-ext": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.12.3.tgz",
-      "integrity": "sha512-7nbrokn02T+WGHLbGq3uNHpYO6AGQUA5BVZSqrUs0FB9mSK203stqdKcW6FKndjUtggchWLecsZV5TQX62Yljg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.13.0.tgz",
+      "integrity": "sha512-0ZMdpPinTQ3Y/xw/neRgwpl8hbWyx8uxpi/9WRtlHEUFuEvTVHjOdZ49t3wePtcnF2iz3spNNNLQeA3THsvM7w==",
       "dependencies": {
         "@inrupt/oidc-client": "^1.11.6",
-        "@inrupt/solid-client-authn-core": "^1.12.3",
+        "@inrupt/solid-client-authn-core": "^1.13.0",
         "jose": "^4.10.0",
         "uuid": "^9.0.0"
       }
@@ -2708,12 +2708,12 @@
       }
     },
     "node_modules/@inrupt/solid-client-authn-browser": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.12.3.tgz",
-      "integrity": "sha512-13w9iQPOl9bzL46AXRKt9R2A0lJbotMFJM754j4CTBNRpCphb49Gd/Q2hQqjSFB++oOVNxfl1dhpT+x13libjw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.13.0.tgz",
+      "integrity": "sha512-2ju6YfdSzxUeup75kCLj6+NRZFSA5YgWk7nlUb6yhBcObWeEZ4W5S1B9qDiJcylp7OeTIfv92REOS+pRJq3fZQ==",
       "dependencies": {
-        "@inrupt/oidc-client-ext": "^1.12.3",
-        "@inrupt/solid-client-authn-core": "^1.12.3",
+        "@inrupt/oidc-client-ext": "^1.13.0",
+        "@inrupt/solid-client-authn-core": "^1.13.0",
         "@types/lodash.clonedeep": "^4.5.6",
         "@types/node": "^18.0.3",
         "@types/uuid": "^8.3.0",
@@ -2732,9 +2732,9 @@
       "integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA=="
     },
     "node_modules/@inrupt/solid-client-authn-core": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.12.3.tgz",
-      "integrity": "sha512-hHVaSSojOC73ag3PyhyKW0FQPu7wMyKJWZhG2RSF+EwIwMUoSVPtsImxG/SU3SnfeQQInUHNfyqWeTNy6k3X8A==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.13.0.tgz",
+      "integrity": "sha512-4C9C9MwZee5m0mAKGDE9t8sjkTuWTuiYpK2mwWUXsRYOSX46nF/wxOBJ6M88YSYqg0dCBPvxDU0Bd6KT7b0+Hg==",
       "dependencies": {
         "cross-fetch": "^3.1.5",
         "events": "^3.3.0",
@@ -24151,9 +24151,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.11.1.tgz",
-      "integrity": "sha512-YRv4Tk/Wlug8qicwqFNFVEZSdbROCHRAC6qu/i0dyNKr5JQdoa2pIGoS04lLO/jXQX7Z9omoNewYIVIxqZBd9Q==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.11.2.tgz",
+      "integrity": "sha512-njj0VL2TsIxCtgzhO+9RRobBvws4oYyCM8TpvoUQwl/MbIM3NFJRR9+e6x0sS5xXaP1t6OCBkaBME98OV9zU5A==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -34529,12 +34529,12 @@
       }
     },
     "@inrupt/oidc-client-ext": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.12.3.tgz",
-      "integrity": "sha512-7nbrokn02T+WGHLbGq3uNHpYO6AGQUA5BVZSqrUs0FB9mSK203stqdKcW6FKndjUtggchWLecsZV5TQX62Yljg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.13.0.tgz",
+      "integrity": "sha512-0ZMdpPinTQ3Y/xw/neRgwpl8hbWyx8uxpi/9WRtlHEUFuEvTVHjOdZ49t3wePtcnF2iz3spNNNLQeA3THsvM7w==",
       "requires": {
         "@inrupt/oidc-client": "^1.11.6",
-        "@inrupt/solid-client-authn-core": "^1.12.3",
+        "@inrupt/solid-client-authn-core": "^1.13.0",
         "jose": "^4.10.0",
         "uuid": "^9.0.0"
       }
@@ -34553,12 +34553,12 @@
       }
     },
     "@inrupt/solid-client-authn-browser": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.12.3.tgz",
-      "integrity": "sha512-13w9iQPOl9bzL46AXRKt9R2A0lJbotMFJM754j4CTBNRpCphb49Gd/Q2hQqjSFB++oOVNxfl1dhpT+x13libjw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.13.0.tgz",
+      "integrity": "sha512-2ju6YfdSzxUeup75kCLj6+NRZFSA5YgWk7nlUb6yhBcObWeEZ4W5S1B9qDiJcylp7OeTIfv92REOS+pRJq3fZQ==",
       "requires": {
-        "@inrupt/oidc-client-ext": "^1.12.3",
-        "@inrupt/solid-client-authn-core": "^1.12.3",
+        "@inrupt/oidc-client-ext": "^1.13.0",
+        "@inrupt/solid-client-authn-core": "^1.13.0",
         "@types/lodash.clonedeep": "^4.5.6",
         "@types/node": "^18.0.3",
         "@types/uuid": "^8.3.0",
@@ -34576,9 +34576,9 @@
       }
     },
     "@inrupt/solid-client-authn-core": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.12.3.tgz",
-      "integrity": "sha512-hHVaSSojOC73ag3PyhyKW0FQPu7wMyKJWZhG2RSF+EwIwMUoSVPtsImxG/SU3SnfeQQInUHNfyqWeTNy6k3X8A==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.13.0.tgz",
+      "integrity": "sha512-4C9C9MwZee5m0mAKGDE9t8sjkTuWTuiYpK2mwWUXsRYOSX46nF/wxOBJ6M88YSYqg0dCBPvxDU0Bd6KT7b0+Hg==",
       "requires": {
         "cross-fetch": "^3.1.5",
         "events": "^3.3.0",
@@ -51158,9 +51158,9 @@
       }
     },
     "jose": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.11.1.tgz",
-      "integrity": "sha512-YRv4Tk/Wlug8qicwqFNFVEZSdbROCHRAC6qu/i0dyNKr5JQdoa2pIGoS04lLO/jXQX7Z9omoNewYIVIxqZBd9Q=="
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.11.2.tgz",
+      "integrity": "sha512-njj0VL2TsIxCtgzhO+9RRobBvws4oYyCM8TpvoUQwl/MbIM3NFJRR9+e6x0sS5xXaP1t6OCBkaBME98OV9zU5A=="
     },
     "js-string-escape": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.8.2",
       "license": "MIT",
       "dependencies": {
-        "@inrupt/solid-client": "^1.23.3",
+        "@inrupt/solid-client": "^1.25.0",
         "@inrupt/solid-client-authn-browser": "^1.12.3",
         "core-js": "^3.18.3",
         "react-table": "^7.6.3",
@@ -2690,21 +2690,21 @@
       }
     },
     "node_modules/@inrupt/solid-client": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.23.3.tgz",
-      "integrity": "sha512-+qzlqtXkM1V2wdZcIWpq6mS+NAfJIeAyWghQBHHLz1hmHiKaE+H0UljOt2B4oSrRYuQq/PYvD/a6N4vfMU+vWg==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.25.0.tgz",
+      "integrity": "sha512-oy9PkvYPRSrntFVekaa8gtC9cK98we0HlV9wE1aI3NAP8ciKQtSv59xfOrj58wQYGLVLkIRQA251qtX2ZGPf4g==",
       "dependencies": {
         "@rdfjs/dataset": "^1.1.0",
-        "@rdfjs/types": "^1.1.0",
-        "@types/n3": "^1.10.0",
-        "@types/rdfjs__dataset": "^1.0.4",
         "cross-fetch": "^3.0.4",
-        "http-link-header": "^1.0.2",
+        "http-link-header": "^1.1.0",
         "jsonld": "^5.2.0",
         "n3": "^1.10.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
       }
     },
     "node_modules/@inrupt/solid-client-authn-browser": {
@@ -11240,15 +11240,6 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
-    "node_modules/@types/n3": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@types/n3/-/n3-1.10.3.tgz",
-      "integrity": "sha512-eVw/weCi6JPooPTz7Zgezmdw5ypNE57Ep+SlxFhT75F0nL9snsu1TIpAMAqtzHvi7VKJKJbnuOxAy9jgFCXDTA==",
-      "dependencies": {
-        "@types/node": "*",
-        "rdf-js": "^4.0.2"
-      }
-    },
     "node_modules/@types/node": {
       "version": "14.14.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.14.tgz",
@@ -11317,14 +11308,6 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
       "dev": true
-    },
-    "node_modules/@types/rdfjs__dataset": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__dataset/-/rdfjs__dataset-1.0.5.tgz",
-      "integrity": "sha512-8OBC9Kr/ZSgNoUTe5mHTDPHaPt8Xen4XbYfqcbYv56d+4WdKliHXaFmFc0L4I5vsynE5JGu21Hvg2zWgX1Az6Q==",
-      "dependencies": {
-        "rdf-js": "^4.0.2"
-      }
     },
     "node_modules/@types/react": {
       "version": "17.0.44",
@@ -19004,7 +18987,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -19761,11 +19743,11 @@
       }
     },
     "node_modules/http-link-header": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.0.3.tgz",
-      "integrity": "sha512-nARK1wSKoBBrtcoESlHBx36c1Ln/gnbNQi1eB6MeTUefJIT3NvUOsV15bClga0k38f0q/kN5xxrGSDS3EFnm9w==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.0.tgz",
+      "integrity": "sha512-pj6N1yxOz/ANO8HHsWGg/OoIL1kmRYvQnXQ7PIRpgp+15AnEsRH8fmIJE6D1OdWG2Bov+BJHVla1fFXxg1JbbA==",
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=6.0.0"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -27212,14 +27194,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/rdf-js": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
-      "integrity": "sha512-ApvlFa/WsQh8LpPK/6hctQwG06Z9ztQQGWVtrcrf9L6+sejHNXLPOqL+w7q3hF+iL0C4sv3AX1PUtGkLNzyZ0Q==",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      }
-    },
     "node_modules/react": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
@@ -34566,16 +34540,14 @@
       }
     },
     "@inrupt/solid-client": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.23.3.tgz",
-      "integrity": "sha512-+qzlqtXkM1V2wdZcIWpq6mS+NAfJIeAyWghQBHHLz1hmHiKaE+H0UljOt2B4oSrRYuQq/PYvD/a6N4vfMU+vWg==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.25.0.tgz",
+      "integrity": "sha512-oy9PkvYPRSrntFVekaa8gtC9cK98we0HlV9wE1aI3NAP8ciKQtSv59xfOrj58wQYGLVLkIRQA251qtX2ZGPf4g==",
       "requires": {
         "@rdfjs/dataset": "^1.1.0",
-        "@rdfjs/types": "^1.1.0",
-        "@types/n3": "^1.10.0",
-        "@types/rdfjs__dataset": "^1.0.4",
         "cross-fetch": "^3.0.4",
-        "http-link-header": "^1.0.2",
+        "fsevents": "^2.3.2",
+        "http-link-header": "^1.1.0",
         "jsonld": "^5.2.0",
         "n3": "^1.10.0"
       }
@@ -40959,15 +40931,6 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
-    "@types/n3": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@types/n3/-/n3-1.10.3.tgz",
-      "integrity": "sha512-eVw/weCi6JPooPTz7Zgezmdw5ypNE57Ep+SlxFhT75F0nL9snsu1TIpAMAqtzHvi7VKJKJbnuOxAy9jgFCXDTA==",
-      "requires": {
-        "@types/node": "*",
-        "rdf-js": "^4.0.2"
-      }
-    },
     "@types/node": {
       "version": "14.14.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.14.tgz",
@@ -41036,14 +40999,6 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
       "dev": true
-    },
-    "@types/rdfjs__dataset": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__dataset/-/rdfjs__dataset-1.0.5.tgz",
-      "integrity": "sha512-8OBC9Kr/ZSgNoUTe5mHTDPHaPt8Xen4XbYfqcbYv56d+4WdKliHXaFmFc0L4I5vsynE5JGu21Hvg2zWgX1Az6Q==",
-      "requires": {
-        "rdf-js": "^4.0.2"
-      }
     },
     "@types/react": {
       "version": "17.0.44",
@@ -47201,7 +47156,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "optional": true
     },
     "function-bind": {
@@ -47810,9 +47764,9 @@
       }
     },
     "http-link-header": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.0.3.tgz",
-      "integrity": "sha512-nARK1wSKoBBrtcoESlHBx36c1Ln/gnbNQi1eB6MeTUefJIT3NvUOsV15bClga0k38f0q/kN5xxrGSDS3EFnm9w=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.0.tgz",
+      "integrity": "sha512-pj6N1yxOz/ANO8HHsWGg/OoIL1kmRYvQnXQ7PIRpgp+15AnEsRH8fmIJE6D1OdWG2Bov+BJHVla1fFXxg1JbbA=="
     },
     "http-proxy-agent": {
       "version": "4.0.1",
@@ -53661,14 +53615,6 @@
       "integrity": "sha512-LXRkhab1QaPJnhUIt1gtXXKswQCZ9zpflsSZFczG7mCLAkMvVjdqCGk9VXCUss0aOUeEyV2jtFxGcdX8DSkj9w==",
       "requires": {
         "setimmediate": "^1.0.5"
-      }
-    },
-    "rdf-js": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
-      "integrity": "sha512-ApvlFa/WsQh8LpPK/6hctQwG06Z9ztQQGWVtrcrf9L6+sejHNXLPOqL+w7q3hF+iL0C4sv3AX1PUtGkLNzyZ0Q==",
-      "requires": {
-        "@rdfjs/types": "*"
       }
     },
     "react": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   },
   "homepage": "https://github.com/inrupt/solid-ui-react#readme",
   "dependencies": {
-    "@inrupt/solid-client": "^1.23.3",
+    "@inrupt/solid-client": "^1.25.0",
     "@inrupt/solid-client-authn-browser": "^1.12.3",
     "core-js": "^3.18.3",
     "react-table": "^7.6.3",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
   "homepage": "https://github.com/inrupt/solid-ui-react#readme",
   "dependencies": {
     "@inrupt/solid-client": "^1.25.0",
-    "@inrupt/solid-client-authn-browser": "^1.12.3",
+    "@inrupt/solid-client-authn-browser": "^1.13.0",
     "core-js": "^3.18.3",
     "react-table": "^7.6.3",
     "stream": "0.0.2",

--- a/src/components/file/index.test.tsx
+++ b/src/components/file/index.test.tsx
@@ -24,7 +24,7 @@ import * as React from "react";
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import { FileUpload } from ".";
 
 const inputOptions = {

--- a/src/components/image/index.test.tsx
+++ b/src/components/image/index.test.tsx
@@ -23,7 +23,7 @@ import React from "react";
 import { render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import type {
   SolidDataset,
   WithChangeLog,

--- a/src/components/link/index.test.tsx
+++ b/src/components/link/index.test.tsx
@@ -21,7 +21,7 @@
 
 import React from "react";
 import { render } from "@testing-library/react";
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import { Link } from ".";
 import * as helpers from "../../helpers";
 

--- a/src/components/table/index.test.tsx
+++ b/src/components/table/index.test.tsx
@@ -25,7 +25,7 @@ import { render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { ErrorBoundary } from "react-error-boundary";
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import { Table, TableColumn } from ".";
 
 const namePredicate = `http://xmlns.com/foaf/0.1/name`;

--- a/src/components/text/index.test.tsx
+++ b/src/components/text/index.test.tsx
@@ -25,7 +25,7 @@ import { render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { ErrorBoundary } from "react-error-boundary";
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import * as helpers from "../../helpers";
 import { Text } from ".";
 import { DatasetProvider } from "../../context/datasetContext";

--- a/src/components/value/boolean/index.test.tsx
+++ b/src/components/value/boolean/index.test.tsx
@@ -24,7 +24,7 @@ import * as React from "react";
 import { render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import * as helpers from "../../../helpers";
 import BooleanValue from ".";
 

--- a/src/components/value/datetime/index.test.tsx
+++ b/src/components/value/datetime/index.test.tsx
@@ -24,7 +24,7 @@ import * as React from "react";
 import { render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import * as helpers from "../../../helpers";
 import DatetimeValue from ".";
 

--- a/src/components/value/decimal/index.test.tsx
+++ b/src/components/value/decimal/index.test.tsx
@@ -24,7 +24,7 @@ import * as React from "react";
 import { render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import * as helpers from "../../../helpers";
 import DecimalValue from ".";
 

--- a/src/components/value/index.test.tsx
+++ b/src/components/value/index.test.tsx
@@ -22,7 +22,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as React from "react";
 import { render } from "@testing-library/react";
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import { Value } from ".";
 import * as helpers from "../../helpers";
 import { DatasetProvider } from "../../context/datasetContext";

--- a/src/components/value/integer/index.test.tsx
+++ b/src/components/value/integer/index.test.tsx
@@ -24,7 +24,7 @@ import * as React from "react";
 import { render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import * as helpers from "../../../helpers";
 import IntegerValue from ".";
 

--- a/src/components/value/string/index.test.tsx
+++ b/src/components/value/string/index.test.tsx
@@ -24,7 +24,7 @@ import * as React from "react";
 import { render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import * as helpers from "../../../helpers";
 import StringValue from ".";
 

--- a/src/components/value/url/index.test.tsx
+++ b/src/components/value/url/index.test.tsx
@@ -24,7 +24,7 @@ import * as React from "react";
 import { render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import * as helpers from "../../../helpers";
 import UrlValue from ".";
 

--- a/src/components/video/index.test.tsx
+++ b/src/components/video/index.test.tsx
@@ -23,7 +23,7 @@ import React from "react";
 import { render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import { Video } from ".";
 import * as helpers from "../../helpers";
 

--- a/src/context/combinedDataContext/index.test.tsx
+++ b/src/context/combinedDataContext/index.test.tsx
@@ -22,7 +22,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as React from "react";
 import { RenderResult, render } from "@testing-library/react";
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import ThingContext from "../thingContext";
 import CombinedProvider from ".";
 

--- a/src/context/datasetContext/index.test.tsx
+++ b/src/context/datasetContext/index.test.tsx
@@ -22,7 +22,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as React from "react";
 import { RenderResult, render, waitFor } from "@testing-library/react";
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import useDataset from "../../hooks/useDataset";
 import DatasetContext, { DatasetProvider } from ".";
 

--- a/src/context/thingContext/index.test.tsx
+++ b/src/context/thingContext/index.test.tsx
@@ -22,7 +22,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as React from "react";
 import { RenderResult, render } from "@testing-library/react";
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import ThingContext, { ThingProvider } from ".";
 import { DatasetProvider } from "../datasetContext";
 

--- a/src/helpers/index.test.tsx
+++ b/src/helpers/index.test.tsx
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import {
   getValueByTypeAll,
   DataType,

--- a/src/hooks/useDataset/index.test.tsx
+++ b/src/hooks/useDataset/index.test.tsx
@@ -22,7 +22,7 @@
 import * as React from "react";
 import { renderHook } from "@testing-library/react-hooks";
 import { SWRConfig } from "swr";
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import { Session } from "@inrupt/solid-client-authn-browser";
 import DatasetContext from "../../context/datasetContext";
 import { SessionContext } from "../../context/sessionContext";

--- a/src/hooks/useFile/index.test.tsx
+++ b/src/hooks/useFile/index.test.tsx
@@ -21,7 +21,7 @@
 
 import * as React from "react";
 import { renderHook } from "@testing-library/react-hooks";
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import { Session } from "@inrupt/solid-client-authn-browser";
 import { SessionContext } from "../../context/sessionContext";
 import useFile from ".";

--- a/src/hooks/useThing/index.test.tsx
+++ b/src/hooks/useThing/index.test.tsx
@@ -21,7 +21,7 @@
 
 import React from "react";
 import { renderHook } from "@testing-library/react-hooks";
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import useDataset from "../useDataset";
 import ThingContext from "../../context/thingContext";
 import useThing from ".";

--- a/stories/components/link.stories.tsx
+++ b/stories/components/link.stories.tsx
@@ -20,7 +20,7 @@
  */
 
 import React, { ReactElement } from "react";
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import { Link } from "../../src/components/link";
 
 export default {

--- a/stories/components/table.stories.tsx
+++ b/stories/components/table.stories.tsx
@@ -20,7 +20,7 @@
  */
 
 import React, { ReactElement, useContext } from "react";
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import DatasetContext, {
   DatasetProvider,
 } from "../../src/context/datasetContext";

--- a/stories/components/tableColumn.stories.tsx
+++ b/stories/components/tableColumn.stories.tsx
@@ -20,7 +20,7 @@
  */
 
 import React, { ReactElement } from "react";
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import { Table, TableColumn } from "../../src/components/table";
 import { DataType } from "../../src/helpers";
 

--- a/stories/components/text.stories.tsx
+++ b/stories/components/text.stories.tsx
@@ -21,7 +21,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { ReactElement } from "react";
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import { Text } from "../../src/components/text";
 import { DatasetProvider } from "../../src/context/datasetContext";
 import { ThingProvider } from "../../src/context/thingContext";

--- a/stories/components/value.stories.tsx
+++ b/stories/components/value.stories.tsx
@@ -21,7 +21,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { ReactElement } from "react";
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import { DataType } from "../../src/helpers";
 import { Value } from "../../src/components/value";
 import { DatasetProvider } from "../../src/context/datasetContext";

--- a/stories/components/video.stories.tsx
+++ b/stories/components/video.stories.tsx
@@ -20,7 +20,7 @@
  */
 
 import React, { ReactElement } from "react";
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import { Video } from "../../src/components/video";
 
 export default {

--- a/stories/providers/combinedProvider.stories.tsx
+++ b/stories/providers/combinedProvider.stories.tsx
@@ -20,7 +20,7 @@
  */
 
 import React, { ReactElement, useContext, useState, useEffect } from "react";
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import ThingContext from "../../src/context/thingContext";
 import CombinedDataProvider from "../../src/context/combinedDataContext";
 import config from "../config";

--- a/stories/providers/datasetProvider.stories.tsx
+++ b/stories/providers/datasetProvider.stories.tsx
@@ -20,7 +20,7 @@
  */
 
 import React, { ReactElement, useContext, useState, useEffect } from "react";
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import DatasetContext, {
   DatasetProvider,
 } from "../../src/context/datasetContext";

--- a/stories/providers/thingProvider.stories.tsx
+++ b/stories/providers/thingProvider.stories.tsx
@@ -20,7 +20,7 @@
  */
 
 import React, { ReactElement, useContext, useState, useEffect } from "react";
-import * as SolidFns from "@inrupt/solid-client";
+import SolidFns from "@inrupt/solid-client";
 import { DatasetProvider } from "../../src/context/datasetContext";
 import ThingContext, { ThingProvider } from "../../src/context/thingContext";
 import config from "../config";


### PR DESCRIPTION
This PR updates: 

- `solid-client` to 1.25.0
- `solid-client-authn-browser` to 1.13.0

There is also a change in imports in test files that was causing an error and failing tests. 