### PR TITLE
Chore: update solid-client to 1.25.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.8.2",
       "license": "MIT",
       "dependencies": {
-        "@inrupt/solid-client": "^1.25.0",
+        "@inrupt/solid-client": "^1.25.1",
         "@inrupt/solid-client-authn-browser": "^1.13.0",
         "core-js": "^3.18.3",
         "react-table": "^7.6.3",
@@ -2705,15 +2705,16 @@
       }
     },
     "node_modules/@inrupt/solid-client": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.25.0.tgz",
-      "integrity": "sha512-oy9PkvYPRSrntFVekaa8gtC9cK98we0HlV9wE1aI3NAP8ciKQtSv59xfOrj58wQYGLVLkIRQA251qtX2ZGPf4g==",
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.25.1.tgz",
+      "integrity": "sha512-9kpiP/jdhMHXQ+Qxjsfmi+/rIkxB1dDbjInL0cQp4R5YZrVhJjNwa2+F2Fz+h5SA2yPD4XefnsSYTJaqh+oEmw==",
       "dependencies": {
         "@rdfjs/dataset": "^1.1.0",
         "cross-fetch": "^3.0.4",
         "http-link-header": "^1.1.0",
         "jsonld": "^5.2.0",
-        "n3": "^1.10.0"
+        "n3": "^1.10.0",
+        "uuid": "^9.0.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.0.0"
@@ -36025,16 +36026,17 @@
       }
     },
     "@inrupt/solid-client": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.25.0.tgz",
-      "integrity": "sha512-oy9PkvYPRSrntFVekaa8gtC9cK98we0HlV9wE1aI3NAP8ciKQtSv59xfOrj58wQYGLVLkIRQA251qtX2ZGPf4g==",
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.25.1.tgz",
+      "integrity": "sha512-9kpiP/jdhMHXQ+Qxjsfmi+/rIkxB1dDbjInL0cQp4R5YZrVhJjNwa2+F2Fz+h5SA2yPD4XefnsSYTJaqh+oEmw==",
       "requires": {
         "@rdfjs/dataset": "^1.1.0",
         "cross-fetch": "^3.0.4",
         "fsevents": "^2.3.2",
         "http-link-header": "^1.1.0",
         "jsonld": "^5.2.0",
-        "n3": "^1.10.0"
+        "n3": "^1.10.0",
+        "uuid": "^9.0.0"
       }
     },
     "@inrupt/solid-client-authn-browser": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   },
   "homepage": "https://github.com/inrupt/solid-ui-react#readme",
   "dependencies": {
-    "@inrupt/solid-client": "^1.25.0",
+    "@inrupt/solid-client": "^1.25.1",
     "@inrupt/solid-client-authn-browser": "^1.13.0",
     "core-js": "^3.18.3",
     "react-table": "^7.6.3",


### PR DESCRIPTION
This PR updates `solid-client` to version 1.25.1.