### PR TITLE
Upgrade to Node 18-compliant dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ["20.x", "18.x", "16.x", "14.x"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+ - Support Node 18 and 20
+
 ## 2.8.3 ( February 6, 2023)
 
 - Dependency updates (notably, upgrading `jest` to v29).

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "2.8.3",
       "license": "MIT",
       "dependencies": {
-        "@inrupt/solid-client": "^1.25.1",
-        "@inrupt/solid-client-authn-browser": "^1.13.0",
+        "@inrupt/solid-client": "^1.27.0",
+        "@inrupt/solid-client-authn-browser": "^1.15.0",
         "core-js": "^3.18.3",
         "react-table": "^7.6.3",
         "stream": "0.0.2",
@@ -2390,6 +2390,40 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@bergos/jsonparse": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@bergos/jsonparse/-/jsonparse-1.4.1.tgz",
+      "integrity": "sha512-vXIT0nzZGX/+yMD5bx2VhTzc92H55tPoehh1BW/FZHOndWGFddrH3MAfdx39FRc7irABirW6EQaGxIJYV6CGuA==",
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "dependencies": {
+        "buffer": "^6.0.3"
+      }
+    },
+    "node_modules/@bergos/jsonparse/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -2436,19 +2470,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@digitalbazaar/http-client": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-1.2.0.tgz",
-      "integrity": "sha512-W9KQQ5pUJcaR0I4c2HPJC0a7kRbZApIorZgPnEDwMBgj16iQzutGLrCXYaZOmxqVLVNqqlQ4aUJh+HBQZy4W6Q==",
-      "dependencies": {
-        "esm": "^3.2.22",
-        "ky": "^0.25.1",
-        "ky-universal": "^0.8.2"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -2694,67 +2715,76 @@
       }
     },
     "node_modules/@inrupt/oidc-client-ext": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.13.0.tgz",
-      "integrity": "sha512-0ZMdpPinTQ3Y/xw/neRgwpl8hbWyx8uxpi/9WRtlHEUFuEvTVHjOdZ49t3wePtcnF2iz3spNNNLQeA3THsvM7w==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.15.0.tgz",
+      "integrity": "sha512-UC/+GlGqQeHudzL1mBLZ/NeEmf8802Mz+xvw9bIG490bPS9RjuwRf5M3Js9dZjV5ckvCVTfsDsnp+ix1ARx3WQ==",
       "dependencies": {
         "@inrupt/oidc-client": "^1.11.6",
-        "@inrupt/solid-client-authn-core": "^1.13.0",
+        "@inrupt/solid-client-authn-core": "^1.15.0",
         "jose": "^4.10.0",
         "uuid": "^9.0.0"
       }
     },
     "node_modules/@inrupt/solid-client": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.25.1.tgz",
-      "integrity": "sha512-9kpiP/jdhMHXQ+Qxjsfmi+/rIkxB1dDbjInL0cQp4R5YZrVhJjNwa2+F2Fz+h5SA2yPD4XefnsSYTJaqh+oEmw==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.27.0.tgz",
+      "integrity": "sha512-OUgsWb5+1a50LKPQBuovHvrqpKwyd/uP5GJ/Lpr7DcD3jzyVAtOvoiVr0IfDPxeiWwI4BR4kTgVlLIRm5UZu9A==",
       "dependencies": {
+        "@inrupt/universal-fetch": "^1.0.1",
         "@rdfjs/dataset": "^1.1.0",
-        "cross-fetch": "^3.0.4",
+        "@types/rdfjs__dataset": "^1.0.4",
         "http-link-header": "^1.1.0",
-        "jsonld": "^5.2.0",
+        "jsonld-context-parser": "^2.3.0",
+        "jsonld-streaming-parser": "^3.2.0",
         "n3": "^1.10.0",
         "uuid": "^9.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.0.0"
+        "node": "^14.17.0 || ^16.0.0 || ^18.0.0"
       },
       "optionalDependencies": {
         "fsevents": "^2.3.2"
       }
     },
     "node_modules/@inrupt/solid-client-authn-browser": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.13.0.tgz",
-      "integrity": "sha512-2ju6YfdSzxUeup75kCLj6+NRZFSA5YgWk7nlUb6yhBcObWeEZ4W5S1B9qDiJcylp7OeTIfv92REOS+pRJq3fZQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.15.0.tgz",
+      "integrity": "sha512-ZuCwVFsJhsbSzJSvRW5DSIWW4AV1MkMYQ4Oe/uRPAw+WMdogQvsbQrPbDYugR9K5XUs+PBr2Iq3r/tNdSuhipA==",
       "dependencies": {
-        "@inrupt/oidc-client-ext": "^1.13.0",
-        "@inrupt/solid-client-authn-core": "^1.13.0",
+        "@inrupt/oidc-client-ext": "^1.15.0",
+        "@inrupt/solid-client-authn-core": "^1.15.0",
+        "@inrupt/universal-fetch": "^1.0.1",
         "@types/lodash.clonedeep": "^4.5.6",
         "@types/node": "^18.0.3",
-        "@types/uuid": "^8.3.0",
+        "@types/uuid": "^9.0.1",
         "events": "^3.3.0",
         "jose": "^4.3.7",
         "lodash.clonedeep": "^4.5.0",
         "uuid": "^9.0.0"
-      },
-      "engines": {
-        "node": "^14.0.0 || ^16.0.0"
       }
     },
     "node_modules/@inrupt/solid-client-authn-core": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.13.0.tgz",
-      "integrity": "sha512-4C9C9MwZee5m0mAKGDE9t8sjkTuWTuiYpK2mwWUXsRYOSX46nF/wxOBJ6M88YSYqg0dCBPvxDU0Bd6KT7b0+Hg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.15.0.tgz",
+      "integrity": "sha512-yvRvDHQZb3EZ2PsNk5GRf5J48FvBK4P3E9crQ2ypfKEE95z71qOae0kHX97PTQbRiYR6F5ECGnLQh4OG+1C+bA==",
       "dependencies": {
-        "cross-fetch": "^3.1.5",
+        "@inrupt/universal-fetch": "^1.0.1",
         "events": "^3.3.0",
         "jose": "^4.10.0",
         "lodash.clonedeep": "^4.5.0",
         "uuid": "^9.0.0"
       },
       "engines": {
-        "node": "^14.0.0 || ^16.0.0"
+        "node": "^14.0.0 || ^16.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@inrupt/universal-fetch": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/universal-fetch/-/universal-fetch-1.0.1.tgz",
+      "integrity": "sha512-oqbG7jS1fa6hVkjSir+u5Ab3eSbyxFyOjsgjDICL27mAd5z8oImTSETnY2hYbkRaJQYKMBOXhtm7L5/+EbeVJg==",
+      "dependencies": {
+        "node-fetch": "^2.6.7",
+        "undici": "^5.19.1"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -10572,6 +10602,14 @@
       "integrity": "sha512-h4lTMgMJctJybDp8CQrxTUiiYmedihHWkjnF/8Pxseu2S6Nlfcy8kwboQ8yejh456rP2yWoEVm1sS/FVsfM48w==",
       "dev": true
     },
+    "node_modules/@types/http-link-header": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.3.tgz",
+      "integrity": "sha512-y8HkoD/vyid+5MrJ3aas0FvU3/BVBGcyG9kgxL0Zn4JwstA8CglFPnrR0RuzOjRCXwqzL5uxWC2IO7Ub0rMU2A==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/is-function": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/is-function/-/is-function-1.0.1.tgz",
@@ -10794,6 +10832,14 @@
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
       "dev": true
     },
+    "node_modules/@types/rdfjs__dataset": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__dataset/-/rdfjs__dataset-1.0.5.tgz",
+      "integrity": "sha512-8OBC9Kr/ZSgNoUTe5mHTDPHaPt8Xen4XbYfqcbYv56d+4WdKliHXaFmFc0L4I5vsynE5JGu21Hvg2zWgX1Az6Q==",
+      "dependencies": {
+        "rdf-js": "^4.0.2"
+      }
+    },
     "node_modules/@types/react": {
       "version": "17.0.44",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.44.tgz",
@@ -10846,6 +10892,20 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
       "integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==",
       "dev": true
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
+      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+      "dependencies": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/@types/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
@@ -10908,9 +10968,9 @@
       "dev": true
     },
     "node_modules/@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA=="
     },
     "node_modules/@types/webpack": {
       "version": "4.41.32",
@@ -13755,6 +13815,17 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -14042,9 +14113,9 @@
       }
     },
     "node_modules/canonicalize": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.5.tgz",
-      "integrity": "sha512-mAjKJPIyP0xqqv6IAkvso07StOmz6cmGtNDg3pXCSzXVZOqka7StIkAhJl/zHOi4M2CgpYfD6aeRWbnrmtvBEA=="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.8.tgz",
+      "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A=="
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -15352,14 +15423,6 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.7.tgz",
       "integrity": "sha512-VvdQIPGdWP0SqFXghj79Wf/5LArmreyMsGLa6FG6iC4t3j7j5s71TrwWmT/4akbDQIqjfACkLZmjXhA7g2oUZw==",
       "dev": true
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/data-urls": {
       "version": "3.0.2",
@@ -17201,14 +17264,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
@@ -17935,14 +17990,6 @@
       "dev": true,
       "dependencies": {
         "bser": "2.1.1"
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-2.1.2.tgz",
-      "integrity": "sha512-YKqtUDwqLyfyMnmbw8XD6Q8j9i/HggKtPEI+pZ1+8bvheBu78biSmNaXWusx1TauGqtUUGx/cBb1mKdq2rLYow==",
-      "engines": {
-        "node": "^10.17.0 || >=12.3.0"
       }
     },
     "node_modules/fetch-retry": {
@@ -19755,7 +19802,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -24000,9 +24046,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.11.2.tgz",
-      "integrity": "sha512-njj0VL2TsIxCtgzhO+9RRobBvws4oYyCM8TpvoUQwl/MbIM3NFJRR9+e6x0sS5xXaP1t6OCBkaBME98OV9zU5A==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.14.0.tgz",
+      "integrity": "sha512-LSA/XenLPwqk6e2L+PSUNuuY9G4NGsvjRWz6sJcUBmzTLEPJqQh46FHSUxnAQ64AWOkRO6bSXpy3yXuEKZkbIA==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -24189,18 +24235,74 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/jsonld": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-5.2.0.tgz",
-      "integrity": "sha512-JymgT6Xzk5CHEmHuEyvoTNviEPxv6ihLWSPu1gFdtjSAyM6cFqNrv02yS/SIur3BBIkCf0HjizRc24d8/FfQKw==",
+    "node_modules/jsonld-context-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.3.0.tgz",
+      "integrity": "sha512-c6w2GE57O26eWFjcPX6k6G86ootsIfpuVwhZKjCll0bVoDGBxr1P4OuU+yvgfnh1GJhAGErolfC7W1BklLjWMg==",
       "dependencies": {
-        "@digitalbazaar/http-client": "^1.1.0",
+        "@types/http-link-header": "^1.0.1",
+        "@types/node": "^18.0.0",
         "canonicalize": "^1.0.1",
-        "lru-cache": "^6.0.0",
-        "rdf-canonize": "^3.0.0"
+        "cross-fetch": "^3.0.6",
+        "http-link-header": "^1.0.2",
+        "relative-to-absolute-iri": "^1.0.5"
+      },
+      "bin": {
+        "jsonld-context-parse": "bin/jsonld-context-parse.js"
+      }
+    },
+    "node_modules/jsonld-streaming-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-3.2.0.tgz",
+      "integrity": "sha512-lJR1SCT364PGpFrOQaY+ZQ7qDWqqiT3IMK+AvZ83fo0LvltFn8/UyXvIFc3RO7YcaEjLahAF0otCi8vOq21NtQ==",
+      "dependencies": {
+        "@bergos/jsonparse": "^1.4.0",
+        "@rdfjs/types": "*",
+        "@types/http-link-header": "^1.0.1",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
+        "canonicalize": "^1.0.1",
+        "http-link-header": "^1.0.2",
+        "jsonld-context-parser": "^2.3.0",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0"
+      }
+    },
+    "node_modules/jsonld-streaming-parser/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/jsonld-streaming-parser/node_modules/readable-stream": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.3.0.tgz",
+      "integrity": "sha512-MuEnA0lbSi7JS8XM+WNJlWZkHAAdm7gETHdFK//Q/mChGyj2akEFtdLZh32jSdkWGbRwCW9pn6g3LWDdDeZnBQ==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10"
       },
       "engines": {
-        "node": ">=12"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/jss": {
@@ -24355,38 +24457,6 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/ky": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/ky/-/ky-0.25.1.tgz",
-      "integrity": "sha512-PjpCEWlIU7VpiMVrTwssahkYXX1by6NCT0fhTUX34F3DTinARlgMpriuroolugFPcMgpPWrOW4mTb984Qm1RXA==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/ky-universal": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.8.2.tgz",
-      "integrity": "sha512-xe0JaOH9QeYxdyGLnzUOVGK4Z6FGvDVzcXFTdrYA1f33MZdEa45sUDaMBy98xQMcsd2XIBrTXRrRYnegcSdgVQ==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "node-fetch": "3.0.0-beta.9"
-      },
-      "engines": {
-        "node": ">=10.17"
-      }
-    },
-    "node_modules/ky-universal/node_modules/node-fetch": {
-      "version": "3.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0-beta.9.tgz",
-      "integrity": "sha512-RdbZCEynH2tH46+tj0ua9caUHVWrd/RHnRfvly2EVdqGmI3ndS1Vn/xjm5KuGejDt2RNDQsVRLPNd2QPwcewVg==",
-      "dependencies": {
-        "data-uri-to-buffer": "^3.0.1",
-        "fetch-blob": "^2.1.1"
-      },
-      "engines": {
-        "node": "^10.17 || >=12.3"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -24708,6 +24778,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -28116,7 +28187,6 @@
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -28461,15 +28531,20 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/rdf-canonize": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-3.0.0.tgz",
-      "integrity": "sha512-LXRkhab1QaPJnhUIt1gtXXKswQCZ9zpflsSZFczG7mCLAkMvVjdqCGk9VXCUss0aOUeEyV2jtFxGcdX8DSkj9w==",
+    "node_modules/rdf-data-factory": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.1.tgz",
+      "integrity": "sha512-0HoLx7lbBlNd2YTmNKin0txgiYmAV56eVU823at8cG2+iD0Ia5kcRNDpzZy6I/HCtFTymHvTfdhHTzm3ak3Jpw==",
       "dependencies": {
-        "setimmediate": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=12"
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/rdf-js": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
+      "integrity": "sha512-ApvlFa/WsQh8LpPK/6hctQwG06Z9ztQQGWVtrcrf9L6+sejHNXLPOqL+w7q3hF+iL0C4sv3AX1PUtGkLNzyZ0Q==",
+      "dependencies": {
+        "@rdfjs/types": "*"
       }
     },
     "node_modules/react": {
@@ -29025,6 +29100,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/relative-to-absolute-iri": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.7.tgz",
+      "integrity": "sha512-Xjyl4HmIzg2jzK/Un2gELqbcE8Fxy85A/aLSHE6PE/3+OGsFwmKVA1vRyGaz6vLWSqLDMHA+5rjD/xbibSQN1Q=="
     },
     "node_modules/remark-external-links": {
       "version": "8.0.0",
@@ -29997,7 +30077,8 @@
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -30634,6 +30715,14 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -32011,6 +32100,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.21.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.21.2.tgz",
+      "integrity": "sha512-f6pTQ9RF4DQtwoWSaC42P/NKlUjvezVvd9r155ohqkwFNRyBKM3f3pcty3ouusefNRyM25XhIQEbeQ46sZDJfQ==",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.18"
       }
     },
     "node_modules/unfetch": {
@@ -33928,7 +34028,8 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yaml": {
       "version": "1.10.0",
@@ -35861,6 +35962,25 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@bergos/jsonparse": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@bergos/jsonparse/-/jsonparse-1.4.1.tgz",
+      "integrity": "sha512-vXIT0nzZGX/+yMD5bx2VhTzc92H55tPoehh1BW/FZHOndWGFddrH3MAfdx39FRc7irABirW6EQaGxIJYV6CGuA==",
+      "requires": {
+        "buffer": "^6.0.3"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        }
+      }
+    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -35897,16 +36017,6 @@
             "@jridgewell/sourcemap-codec": "^1.4.10"
           }
         }
-      }
-    },
-    "@digitalbazaar/http-client": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-1.2.0.tgz",
-      "integrity": "sha512-W9KQQ5pUJcaR0I4c2HPJC0a7kRbZApIorZgPnEDwMBgj16iQzutGLrCXYaZOmxqVLVNqqlQ4aUJh+HBQZy4W6Q==",
-      "requires": {
-        "esm": "^3.2.22",
-        "ky": "^0.25.1",
-        "ky-universal": "^0.8.2"
       }
     },
     "@discoveryjs/json-ext": {
@@ -36115,40 +36225,43 @@
       }
     },
     "@inrupt/oidc-client-ext": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.13.0.tgz",
-      "integrity": "sha512-0ZMdpPinTQ3Y/xw/neRgwpl8hbWyx8uxpi/9WRtlHEUFuEvTVHjOdZ49t3wePtcnF2iz3spNNNLQeA3THsvM7w==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.15.0.tgz",
+      "integrity": "sha512-UC/+GlGqQeHudzL1mBLZ/NeEmf8802Mz+xvw9bIG490bPS9RjuwRf5M3Js9dZjV5ckvCVTfsDsnp+ix1ARx3WQ==",
       "requires": {
         "@inrupt/oidc-client": "^1.11.6",
-        "@inrupt/solid-client-authn-core": "^1.13.0",
+        "@inrupt/solid-client-authn-core": "^1.15.0",
         "jose": "^4.10.0",
         "uuid": "^9.0.0"
       }
     },
     "@inrupt/solid-client": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.25.1.tgz",
-      "integrity": "sha512-9kpiP/jdhMHXQ+Qxjsfmi+/rIkxB1dDbjInL0cQp4R5YZrVhJjNwa2+F2Fz+h5SA2yPD4XefnsSYTJaqh+oEmw==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.27.0.tgz",
+      "integrity": "sha512-OUgsWb5+1a50LKPQBuovHvrqpKwyd/uP5GJ/Lpr7DcD3jzyVAtOvoiVr0IfDPxeiWwI4BR4kTgVlLIRm5UZu9A==",
       "requires": {
+        "@inrupt/universal-fetch": "^1.0.1",
         "@rdfjs/dataset": "^1.1.0",
-        "cross-fetch": "^3.0.4",
+        "@types/rdfjs__dataset": "^1.0.4",
         "fsevents": "^2.3.2",
         "http-link-header": "^1.1.0",
-        "jsonld": "^5.2.0",
+        "jsonld-context-parser": "^2.3.0",
+        "jsonld-streaming-parser": "^3.2.0",
         "n3": "^1.10.0",
         "uuid": "^9.0.0"
       }
     },
     "@inrupt/solid-client-authn-browser": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.13.0.tgz",
-      "integrity": "sha512-2ju6YfdSzxUeup75kCLj6+NRZFSA5YgWk7nlUb6yhBcObWeEZ4W5S1B9qDiJcylp7OeTIfv92REOS+pRJq3fZQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.15.0.tgz",
+      "integrity": "sha512-ZuCwVFsJhsbSzJSvRW5DSIWW4AV1MkMYQ4Oe/uRPAw+WMdogQvsbQrPbDYugR9K5XUs+PBr2Iq3r/tNdSuhipA==",
       "requires": {
-        "@inrupt/oidc-client-ext": "^1.13.0",
-        "@inrupt/solid-client-authn-core": "^1.13.0",
+        "@inrupt/oidc-client-ext": "^1.15.0",
+        "@inrupt/solid-client-authn-core": "^1.15.0",
+        "@inrupt/universal-fetch": "^1.0.1",
         "@types/lodash.clonedeep": "^4.5.6",
         "@types/node": "^18.0.3",
-        "@types/uuid": "^8.3.0",
+        "@types/uuid": "^9.0.1",
         "events": "^3.3.0",
         "jose": "^4.3.7",
         "lodash.clonedeep": "^4.5.0",
@@ -36156,15 +36269,24 @@
       }
     },
     "@inrupt/solid-client-authn-core": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.13.0.tgz",
-      "integrity": "sha512-4C9C9MwZee5m0mAKGDE9t8sjkTuWTuiYpK2mwWUXsRYOSX46nF/wxOBJ6M88YSYqg0dCBPvxDU0Bd6KT7b0+Hg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.15.0.tgz",
+      "integrity": "sha512-yvRvDHQZb3EZ2PsNk5GRf5J48FvBK4P3E9crQ2ypfKEE95z71qOae0kHX97PTQbRiYR6F5ECGnLQh4OG+1C+bA==",
       "requires": {
-        "cross-fetch": "^3.1.5",
+        "@inrupt/universal-fetch": "^1.0.1",
         "events": "^3.3.0",
         "jose": "^4.10.0",
         "lodash.clonedeep": "^4.5.0",
         "uuid": "^9.0.0"
+      }
+    },
+    "@inrupt/universal-fetch": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/universal-fetch/-/universal-fetch-1.0.1.tgz",
+      "integrity": "sha512-oqbG7jS1fa6hVkjSir+u5Ab3eSbyxFyOjsgjDICL27mAd5z8oImTSETnY2hYbkRaJQYKMBOXhtm7L5/+EbeVJg==",
+      "requires": {
+        "node-fetch": "^2.6.7",
+        "undici": "^5.19.1"
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -41901,6 +42023,14 @@
       "integrity": "sha512-h4lTMgMJctJybDp8CQrxTUiiYmedihHWkjnF/8Pxseu2S6Nlfcy8kwboQ8yejh456rP2yWoEVm1sS/FVsfM48w==",
       "dev": true
     },
+    "@types/http-link-header": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.3.tgz",
+      "integrity": "sha512-y8HkoD/vyid+5MrJ3aas0FvU3/BVBGcyG9kgxL0Zn4JwstA8CglFPnrR0RuzOjRCXwqzL5uxWC2IO7Ub0rMU2A==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/is-function": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/is-function/-/is-function-1.0.1.tgz",
@@ -42109,6 +42239,14 @@
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
       "dev": true
     },
+    "@types/rdfjs__dataset": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__dataset/-/rdfjs__dataset-1.0.5.tgz",
+      "integrity": "sha512-8OBC9Kr/ZSgNoUTe5mHTDPHaPt8Xen4XbYfqcbYv56d+4WdKliHXaFmFc0L4I5vsynE5JGu21Hvg2zWgX1Az6Q==",
+      "requires": {
+        "rdf-js": "^4.0.2"
+      }
+    },
     "@types/react": {
       "version": "17.0.44",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.44.tgz",
@@ -42162,6 +42300,22 @@
       "dev": true,
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/readable-stream": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
+      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+      "requires": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
     },
     "@types/scheduler": {
@@ -42224,9 +42378,9 @@
       "dev": true
     },
     "@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA=="
     },
     "@types/webpack": {
       "version": "4.41.32",
@@ -44417,6 +44571,14 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "requires": {
+        "streamsearch": "^1.1.0"
+      }
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -44633,9 +44795,9 @@
       "dev": true
     },
     "canonicalize": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.5.tgz",
-      "integrity": "sha512-mAjKJPIyP0xqqv6IAkvso07StOmz6cmGtNDg3pXCSzXVZOqka7StIkAhJl/zHOi4M2CgpYfD6aeRWbnrmtvBEA=="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.8.tgz",
+      "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -45718,11 +45880,6 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.7.tgz",
       "integrity": "sha512-VvdQIPGdWP0SqFXghj79Wf/5LArmreyMsGLa6FG6iC4t3j7j5s71TrwWmT/4akbDQIqjfACkLZmjXhA7g2oUZw==",
       "dev": true
-    },
-    "data-uri-to-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
     },
     "data-urls": {
       "version": "3.0.2",
@@ -47182,11 +47339,6 @@
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true
     },
-    "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
-    },
     "espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
@@ -47781,11 +47933,6 @@
       "requires": {
         "bser": "2.1.1"
       }
-    },
-    "fetch-blob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-2.1.2.tgz",
-      "integrity": "sha512-YKqtUDwqLyfyMnmbw8XD6Q8j9i/HggKtPEI+pZ1+8bvheBu78biSmNaXWusx1TauGqtUUGx/cBb1mKdq2rLYow=="
     },
     "fetch-retry": {
       "version": "5.0.3",
@@ -49233,8 +49380,7 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "iferr": {
       "version": "0.1.5",
@@ -52374,9 +52520,9 @@
       }
     },
     "jose": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.11.2.tgz",
-      "integrity": "sha512-njj0VL2TsIxCtgzhO+9RRobBvws4oYyCM8TpvoUQwl/MbIM3NFJRR9+e6x0sS5xXaP1t6OCBkaBME98OV9zU5A=="
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.14.0.tgz",
+      "integrity": "sha512-LSA/XenLPwqk6e2L+PSUNuuY9G4NGsvjRWz6sJcUBmzTLEPJqQh46FHSUxnAQ64AWOkRO6bSXpy3yXuEKZkbIA=="
     },
     "js-string-escape": {
       "version": "1.0.1",
@@ -52513,15 +52659,56 @@
         "universalify": "^2.0.0"
       }
     },
-    "jsonld": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-5.2.0.tgz",
-      "integrity": "sha512-JymgT6Xzk5CHEmHuEyvoTNviEPxv6ihLWSPu1gFdtjSAyM6cFqNrv02yS/SIur3BBIkCf0HjizRc24d8/FfQKw==",
+    "jsonld-context-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.3.0.tgz",
+      "integrity": "sha512-c6w2GE57O26eWFjcPX6k6G86ootsIfpuVwhZKjCll0bVoDGBxr1P4OuU+yvgfnh1GJhAGErolfC7W1BklLjWMg==",
       "requires": {
-        "@digitalbazaar/http-client": "^1.1.0",
+        "@types/http-link-header": "^1.0.1",
+        "@types/node": "^18.0.0",
         "canonicalize": "^1.0.1",
-        "lru-cache": "^6.0.0",
-        "rdf-canonize": "^3.0.0"
+        "cross-fetch": "^3.0.6",
+        "http-link-header": "^1.0.2",
+        "relative-to-absolute-iri": "^1.0.5"
+      }
+    },
+    "jsonld-streaming-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-3.2.0.tgz",
+      "integrity": "sha512-lJR1SCT364PGpFrOQaY+ZQ7qDWqqiT3IMK+AvZ83fo0LvltFn8/UyXvIFc3RO7YcaEjLahAF0otCi8vOq21NtQ==",
+      "requires": {
+        "@bergos/jsonparse": "^1.4.0",
+        "@rdfjs/types": "*",
+        "@types/http-link-header": "^1.0.1",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
+        "canonicalize": "^1.0.1",
+        "http-link-header": "^1.0.2",
+        "jsonld-context-parser": "^2.3.0",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "readable-stream": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.3.0.tgz",
+          "integrity": "sha512-MuEnA0lbSi7JS8XM+WNJlWZkHAAdm7gETHdFK//Q/mChGyj2akEFtdLZh32jSdkWGbRwCW9pn6g3LWDdDeZnBQ==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^6.0.3",
+            "events": "^3.3.0",
+            "process": "^0.11.10"
+          }
+        }
       }
     },
     "jss": {
@@ -52660,31 +52847,6 @@
       "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
       "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
       "dev": true
-    },
-    "ky": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/ky/-/ky-0.25.1.tgz",
-      "integrity": "sha512-PjpCEWlIU7VpiMVrTwssahkYXX1by6NCT0fhTUX34F3DTinARlgMpriuroolugFPcMgpPWrOW4mTb984Qm1RXA=="
-    },
-    "ky-universal": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.8.2.tgz",
-      "integrity": "sha512-xe0JaOH9QeYxdyGLnzUOVGK4Z6FGvDVzcXFTdrYA1f33MZdEa45sUDaMBy98xQMcsd2XIBrTXRrRYnegcSdgVQ==",
-      "requires": {
-        "abort-controller": "^3.0.0",
-        "node-fetch": "3.0.0-beta.9"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "3.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0-beta.9.tgz",
-          "integrity": "sha512-RdbZCEynH2tH46+tj0ua9caUHVWrd/RHnRfvly2EVdqGmI3ndS1Vn/xjm5KuGejDt2RNDQsVRLPNd2QPwcewVg==",
-          "requires": {
-            "data-uri-to-buffer": "^3.0.1",
-            "fetch-blob": "^2.1.1"
-          }
-        }
-      }
     },
     "language-subtag-registry": {
       "version": "0.3.21",
@@ -52951,6 +53113,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -55501,8 +55664,7 @@
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -55788,12 +55950,20 @@
         }
       }
     },
-    "rdf-canonize": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-3.0.0.tgz",
-      "integrity": "sha512-LXRkhab1QaPJnhUIt1gtXXKswQCZ9zpflsSZFczG7mCLAkMvVjdqCGk9VXCUss0aOUeEyV2jtFxGcdX8DSkj9w==",
+    "rdf-data-factory": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.1.tgz",
+      "integrity": "sha512-0HoLx7lbBlNd2YTmNKin0txgiYmAV56eVU823at8cG2+iD0Ia5kcRNDpzZy6I/HCtFTymHvTfdhHTzm3ak3Jpw==",
       "requires": {
-        "setimmediate": "^1.0.5"
+        "@rdfjs/types": "*"
+      }
+    },
+    "rdf-js": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
+      "integrity": "sha512-ApvlFa/WsQh8LpPK/6hctQwG06Z9ztQQGWVtrcrf9L6+sejHNXLPOqL+w7q3hF+iL0C4sv3AX1PUtGkLNzyZ0Q==",
+      "requires": {
+        "@rdfjs/types": "*"
       }
     },
     "react": {
@@ -56262,6 +56432,11 @@
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
       "dev": true
+    },
+    "relative-to-absolute-iri": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.7.tgz",
+      "integrity": "sha512-Xjyl4HmIzg2jzK/Un2gELqbcE8Fxy85A/aLSHE6PE/3+OGsFwmKVA1vRyGaz6vLWSqLDMHA+5rjD/xbibSQN1Q=="
     },
     "remark-external-links": {
       "version": "8.0.0",
@@ -57045,7 +57220,8 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
     },
     "setprototypeof": {
       "version": "1.2.0",
@@ -57610,6 +57786,11 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
+    },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -58631,6 +58812,14 @@
         "has-bigints": "^1.0.2",
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
+      }
+    },
+    "undici": {
+      "version": "5.21.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.21.2.tgz",
+      "integrity": "sha512-f6pTQ9RF4DQtwoWSaC42P/NKlUjvezVvd9r155ohqkwFNRyBKM3f3pcty3ouusefNRyM25XhIQEbeQ46sZDJfQ==",
+      "requires": {
+        "busboy": "^1.6.0"
       }
     },
     "unfetch": {
@@ -60204,7 +60393,8 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "yaml": {
       "version": "1.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@inrupt/eslint-config-base": "0.3.0",
         "@inrupt/eslint-config-lib": "^0.3.0",
         "@inrupt/eslint-config-react": "0.3.0",
-        "@inrupt/jest-jsdom-polyfills": "^1.5.4",
+        "@inrupt/jest-jsdom-polyfills": "^1.6.2",
         "@material-ui/core": "^4.12.4",
         "@storybook/addon-actions": "^6.5.16",
         "@storybook/addon-docs": "^6.5.16",
@@ -2692,14 +2692,15 @@
       }
     },
     "node_modules/@inrupt/jest-jsdom-polyfills": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@inrupt/jest-jsdom-polyfills/-/jest-jsdom-polyfills-1.5.4.tgz",
-      "integrity": "sha512-zOEReHX++nB40UVJPOZRgtmnVA8WwxzfrsGgTv2PwnIf5dqQoHPQzM4eeHjnOX/iommptxXgiPsLoJ6ur5UOnQ==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@inrupt/jest-jsdom-polyfills/-/jest-jsdom-polyfills-1.6.2.tgz",
+      "integrity": "sha512-u0dU576x/mkQ6JesaEUzN3bNk8Xx7OAhLW79h9AW2QPcEjoRIAxG7ZXlKYXz+a//c/k2kRWAysxksOuugsQalA==",
       "dev": true,
       "dependencies": {
         "@peculiar/webcrypto": "^1.4.0",
         "@web-std/blob": "^3.0.4",
-        "@web-std/file": "^3.0.2"
+        "@web-std/file": "^3.0.2",
+        "undici": "^5.20.0"
       }
     },
     "node_modules/@inrupt/oidc-client": {
@@ -36202,14 +36203,15 @@
       "requires": {}
     },
     "@inrupt/jest-jsdom-polyfills": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@inrupt/jest-jsdom-polyfills/-/jest-jsdom-polyfills-1.5.4.tgz",
-      "integrity": "sha512-zOEReHX++nB40UVJPOZRgtmnVA8WwxzfrsGgTv2PwnIf5dqQoHPQzM4eeHjnOX/iommptxXgiPsLoJ6ur5UOnQ==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@inrupt/jest-jsdom-polyfills/-/jest-jsdom-polyfills-1.6.2.tgz",
+      "integrity": "sha512-u0dU576x/mkQ6JesaEUzN3bNk8Xx7OAhLW79h9AW2QPcEjoRIAxG7ZXlKYXz+a//c/k2kRWAysxksOuugsQalA==",
       "dev": true,
       "requires": {
         "@peculiar/webcrypto": "^1.4.0",
         "@web-std/blob": "^3.0.4",
-        "@web-std/file": "^3.0.2"
+        "@web-std/file": "^3.0.2",
+        "undici": "^5.20.0"
       }
     },
     "@inrupt/oidc-client": {

--- a/package.json
+++ b/package.json
@@ -101,8 +101,8 @@
   },
   "homepage": "https://github.com/inrupt/solid-ui-react#readme",
   "dependencies": {
-    "@inrupt/solid-client": "^1.25.1",
-    "@inrupt/solid-client-authn-browser": "^1.13.0",
+    "@inrupt/solid-client": "^1.27.0",
+    "@inrupt/solid-client-authn-browser": "^1.15.0",
     "core-js": "^3.18.3",
     "react-table": "^7.6.3",
     "stream": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@inrupt/eslint-config-base": "0.3.0",
     "@inrupt/eslint-config-lib": "^0.3.0",
     "@inrupt/eslint-config-react": "0.3.0",
-    "@inrupt/jest-jsdom-polyfills": "^1.5.4",
+    "@inrupt/jest-jsdom-polyfills": "^1.6.2",
     "@material-ui/core": "^4.12.4",
     "@storybook/addon-actions": "^6.5.16",
     "@storybook/addon-docs": "^6.5.16",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
-    "react": ">16.13.0 || ^17.0.0 || ^18.0.0"
+    "react": ">16.13.0 || ^17.0.0 || ^18.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.17.9",

--- a/src/components/value/boolean/index.test.tsx
+++ b/src/components/value/boolean/index.test.tsx
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { jest, it, describe, expect } from "@jest/globals";
+import { jest, it, describe, expect, beforeEach } from "@jest/globals";
 
 import * as React from "react";
 import { render, waitFor } from "@testing-library/react";
@@ -61,7 +61,6 @@ const mockDatasetFromWithChangelog = (url: string) =>
     // Pretend we have a changelog, even though we don't, as it's irrelevant to these tests.
     SolidClient.WithChangeLog;
 
-
 const mockPredicate = `http://some.vocabulary/isTrue`;
 const mockBoolean = '"true"^^xsd:boolean';
 
@@ -87,13 +86,11 @@ const savedDataset = SolidFns.setThing(
   SolidFns.mockSolidDatasetFrom("https://example.pod/resource"),
   SolidFns.createThing()
 );
-const latestDataset = SolidFns.setThing(savedDataset, SolidFns.createThing());
 
-jest.spyOn(SolidFns, "saveSolidDatasetAt").mockResolvedValue(savedDataset);
 const mockValue = true;
 
 describe("<BooleanValue /> component functional testing", () => {
-  afterEach(() => {
+  beforeEach(() => {
     jest.clearAllMocks();
   });
   it("calls getBoolean and sets value", () => {
@@ -171,8 +168,11 @@ describe("<BooleanValue /> component functional testing", () => {
     );
 
     // Be careful to call spyOn after the setup is done.
+    jest.clearAllMocks();
+
     jest.spyOn(SolidFns, "setBoolean");
 
+    expect(SolidFns.setBoolean).not.toHaveBeenCalled();
     const { getByDisplayValue } = render(
       <BooleanValue
         solidDataset={mockedDataset}


### PR DESCRIPTION
This adds support for Node 18 and Node 20. It fixes a couple of issues with the unit tests, but there are likely additional issues with the unchanged tests. A global review will be needed, but that's out of scope for this.